### PR TITLE
저장 나가기 버튼 연동 및 씬 전환될때 오류 수정

### DIFF
--- a/Assets/Prefabs/SettingUI.prefab
+++ b/Assets/Prefabs/SettingUI.prefab
@@ -776,7 +776,7 @@ GameObject:
   - component: {fileID: 2601500971310265082}
   - component: {fileID: 7825262664982678449}
   m_Layer: 5
-  m_Name: Button (1)
+  m_Name: Button - Exit
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -897,7 +897,7 @@ GameObject:
   - component: {fileID: 942965871216427832}
   - component: {fileID: 6005120779471784011}
   m_Layer: 5
-  m_Name: Button
+  m_Name: Button - Save
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -2142,6 +2142,8 @@ MonoBehaviour:
   mouseSensitivityInputField: {fileID: 7089436688560514489}
   bgmText: {fileID: 3270130292013561642}
   sfxText: {fileID: 6080830892517717406}
+  saveButton: {fileID: 6005120779471784011}
+  exitButton: {fileID: 7825262664982678449}
 --- !u!1 &4749733500898118951
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Player/PlayerController.cs
+++ b/Assets/Scripts/Player/PlayerController.cs
@@ -32,6 +32,9 @@ public class PlayerController : MonoBehaviour
             GameManager.instance.OnPlayerPosChanged += ChangePosition;
 
             myRigid.MovePosition(GameManager.instance.LoadPlayerPos());
+
+            GameManager.instance.Resume();
+            playerLook.enabled = true;
         }
     }
     void FixedUpdate()

--- a/Assets/Scripts/SettingManager.cs
+++ b/Assets/Scripts/SettingManager.cs
@@ -1,9 +1,8 @@
-﻿using System.Collections.Generic;
-using TMPro;
-using UnityEditor.Rendering;
+﻿using TMPro;
 using UnityEngine;
 using UnityEngine.UI;
 using UnityEngine.Audio;
+using UnityEngine.SceneManagement;
 
 public class SettingManager : MonoBehaviour
 {
@@ -22,6 +21,9 @@ public class SettingManager : MonoBehaviour
     // 텍스트 변수 추가
     public TextMeshProUGUI bgmText;
     public TextMeshProUGUI sfxText;
+
+    public Button saveButton;
+    public Button exitButton;
 
     private const string MouseSensitivityKey = "MouseSensitivity";
     private const string BgmVolumeKey = "BgmVolume";
@@ -58,6 +60,9 @@ public class SettingManager : MonoBehaviour
 
         GameObject playerObject = GameObject.FindWithTag("Player");
         playerLook = playerObject.GetComponent<PlayerLook>();
+
+        saveButton.onClick.AddListener(OnclickSaveButton);
+        exitButton.onClick.AddListener(OnclickExitButton);
     }
 
     void Update()
@@ -190,4 +195,16 @@ public class SettingManager : MonoBehaviour
         }
     }
 
+    public void OnclickSaveButton()
+    {
+        GameData gameData = GameManager.instance.SaveData();
+        DataManager.instance.SaveGameData(gameData);
+    }
+
+    public void OnclickExitButton()
+    {
+        GameData gameData = GameManager.instance.SaveData();
+        DataManager.instance.SaveGameData(gameData);
+        SceneManager.LoadScene("Title");
+    }
 }


### PR DESCRIPTION
문제점: 씬 전환 후 마우스의 좌우 이동에 오류가 발생, 
오류: 게임 메니저의 퍼즈 리줌 호출한 데이터가 씬전환해도 남아있어서 오류가 생긴것이라고 판단됨
=> 좌우 시점 이동은 RigidBody여서 타임 스케일이 0f라 잠김, 상하 이동은 카메라 이동이라 영향을 받지 않아서 움직임 가능