### PR TITLE
이벤트 시스템을 이용한 설정 메뉴 활성화 조건 추가

### DIFF
--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -9,6 +9,7 @@ public class GameManager : MonoBehaviour
     public event Action<Vector3> OnPlayerPosChanged;
     public event Action OnUnlockDoor;
     public event Func<int> OnRequestDoorLock;
+    public event Action<bool> OnSlotMachineStateChanged;
 
     private bool isGaimng;
     public LevelData levelData { get; private set; }
@@ -117,5 +118,10 @@ public class GameManager : MonoBehaviour
     {
         Debug.Log($"레벨이 {levelData._level}(으)로 변경되었습니다. 문 잠금 해제를 시도합니다.");
         OnUnlockDoor?.Invoke();
+    }
+
+    public void CheckSlotMachineStateChanged(bool newState)
+    {
+        OnSlotMachineStateChanged?.Invoke(newState);
     }
 }

--- a/Assets/Scripts/Player/PlayerLook.cs
+++ b/Assets/Scripts/Player/PlayerLook.cs
@@ -174,6 +174,7 @@ public class PlayerLook : MonoBehaviour
 
         Cursor.lockState = CursorLockMode.None;
         Cursor.visible = true;
+        GameManager.instance.CheckSlotMachineStateChanged(false);
     }
 
     public void UnfixViewPoint()
@@ -184,6 +185,7 @@ public class PlayerLook : MonoBehaviour
 
         Cursor.lockState = CursorLockMode.Locked;
         Cursor.visible = false;
+        GameManager.instance.CheckSlotMachineStateChanged(true);
     }
 
     /// 고정 시점으로 전환하는 속도

--- a/Assets/Scripts/SettingManager.cs
+++ b/Assets/Scripts/SettingManager.cs
@@ -29,6 +29,7 @@ public class SettingManager : MonoBehaviour
     private const string BgmVolumeKey = "BgmVolume";
     private const string SfxVolumeKey = "SfxVolume";
 
+    private bool isSlotmachineState = false;
     void Start()
     {
         // 게임 시작 시 설정 패널을 비활성화(숨기기)합니다.
@@ -63,12 +64,14 @@ public class SettingManager : MonoBehaviour
 
         saveButton.onClick.AddListener(OnclickSaveButton);
         exitButton.onClick.AddListener(OnclickExitButton);
+
+        GameManager.instance.OnSlotMachineStateChanged += HandleSlotStateChange;
     }
 
     void Update()
     {
-        // 'P' 키를 누를 때마다 'ToggleSettings' 함수를 호출합니다.
-        if (Input.GetKeyDown(KeyCode.Escape))
+        if (isSlotmachineState &&
+            Input.GetKeyDown(KeyCode.Escape))
         {
             ToggleSettings();
         }
@@ -206,5 +209,10 @@ public class SettingManager : MonoBehaviour
         GameData gameData = GameManager.instance.SaveData();
         DataManager.instance.SaveGameData(gameData);
         SceneManager.LoadScene("Title");
+    }
+
+    private void HandleSlotStateChange(bool newState)
+    {
+        isSlotmachineState = newState;
     }
 }


### PR DESCRIPTION
플레이어가 슬롯머신과 같은 특정 오브젝트와 상호작용 중일 때 ESC 키로 설정 메뉴가 열리는 문제를 해결했습니다.

- GameManager에 OnSlotMachineStateChanged 이벤트를 추가하여 중앙에서 상태를 관리하도록 구현.
- PlayerLook(상호작용 주체)이 시점 고정/해제 시 GameManager의 이벤트를 발생시켜 현재 상태를 전파.
- SettingManager가 이벤트를 구독하여, 플레이어가 상호작용 중이 아닐 때만 설정 메뉴를 열 수 있도록 로직을 수정.

이를 통해 각 클래스 간의 의존성을 낮추고 코드의 확장성을 높였습니다.

https://github.com/user-attachments/assets/d2632c35-3592-4d24-8c3b-8d1d3d0f4983

