### PR TITLE
114 아이템의 데이터 추가

### DIFF
--- a/Assets/ScriptableObject/ItemData.cs
+++ b/Assets/ScriptableObject/ItemData.cs
@@ -2,20 +2,6 @@ using UnityEngine;
 using System;
 using System.Collections.Generic;
 
-public enum ItemType
-{
-    None,
-    CanUseItem,
-    Skill
-}
-
-public enum Goods
-{
-    None,
-    Gold,
-    Tokken
-}
-
 public enum UseType
 {
     None,
@@ -94,9 +80,7 @@ public struct ItemEffetModel
 public struct ItemDataModel
 {
     public int id;
-    public ItemType itemType;
     public string name;
-    public Goods goods;
     public int price;
     public Rarity rarity;
     public HasRisk hasRisk;
@@ -107,25 +91,5 @@ public struct ItemDataModel
 [CreateAssetMenu(fileName = "ItmeData", menuName = "Scriptable Objects/ItmeData")]
 public class ItmeData : ScriptableObject
 {
-    public List<ItemDataModel> canUseItemDataModels;
-    public List<ItemDataModel> SkillDataModels;
-
-    private void OnValidate()
-    {
-        for (int i = 0; i < canUseItemDataModels.Count; i++)
-        {
-            ItemDataModel item = canUseItemDataModels[i];
-            item.itemType = ItemType.CanUseItem; 
-            item.goods = Goods.Gold;
-            canUseItemDataModels[i] = item;  
-        }
-
-        for (int i = 0; i < SkillDataModels.Count; i++)
-        {
-            ItemDataModel item = SkillDataModels[i];
-            item.itemType = ItemType.Skill;
-            item.goods = Goods.Tokken;
-            SkillDataModels[i] = item;
-        }
-    }
+    public List<ItemDataModel> itemDataModels;
 }

--- a/Assets/ScriptableObject/ItemData.cs
+++ b/Assets/ScriptableObject/ItemData.cs
@@ -1,0 +1,131 @@
+using UnityEngine;
+using System;
+using System.Collections.Generic;
+
+public enum ItemType
+{
+    None,
+    CanUseItem,
+    Skill
+}
+
+public enum Goods
+{
+    None,
+    Gold,
+    Tokken
+}
+
+public enum UseType
+{
+    None,
+    Symbol,
+    SymbolReward,
+    PartternReward,
+    Stress
+}
+
+[Flags]
+public enum FlagPatterns
+{
+    None = 0,
+    Column_3 = 1,
+    Column_4 = 2,
+    Column_5 = 4,
+    Row_3 = 8,
+    LowerDiagonal = 16,
+    UpperDiagonal = 32,
+    Zig = 64,
+    Zag = 128,
+    Up = 256,
+    Down = 512,
+    Eyes = 1024,
+    Jackpot = 2048
+}
+
+[Flags]
+public enum FlagSymbols
+{
+    None = 0,
+    Cherry = 1,
+    Banana = 2,
+    Carrot = 4,
+    Bell = 8,
+    Diamond = 16,
+    Star = 32,
+    Seven = 64
+}
+
+public enum StressType
+{
+    None,
+    CurrentStress,
+    MaxStress
+}
+
+public enum Rarity
+{
+    None,
+    Common,
+    Rare,
+    Unique,
+    Legendary
+}
+
+public enum HasRisk
+{
+    None,
+    Good,
+    Risk,
+    Both
+}
+
+[Serializable]
+public struct ItemEffetModel
+{
+    public UseType useType;
+    public FlagSymbols flagSymbols;
+    public FlagPatterns flagPatterns;
+    public StressType stressType;
+    public int amount;
+}
+
+[Serializable]
+public struct ItemDataModel
+{
+    public int id;
+    public ItemType itemType;
+    public string name;
+    public Goods goods;
+    public int price;
+    public Rarity rarity;
+    public HasRisk hasRisk;
+    public ItemEffetModel itmeEffect;
+    public ItemEffetModel itmeRiskEffect;
+}
+
+[CreateAssetMenu(fileName = "ItmeData", menuName = "Scriptable Objects/ItmeData")]
+public class ItmeData : ScriptableObject
+{
+    public List<ItemDataModel> canUseItemDataModels;
+    public List<ItemDataModel> SkillDataModels;
+
+    private void OnValidate()
+    {
+        for (int i = 0; i < canUseItemDataModels.Count; i++)
+        {
+            ItemDataModel item = canUseItemDataModels[i];
+            item.itemType = ItemType.CanUseItem; 
+            item.goods = Goods.Gold;
+            canUseItemDataModels[i] = item;  
+        }
+
+        for (int i = 0; i < SkillDataModels.Count; i++)
+        {
+            ItemDataModel item = SkillDataModels[i];
+            item.itemType = ItemType.Skill;
+            item.goods = Goods.Tokken;
+            SkillDataModels[i] = item;
+        }
+    }
+}

--- a/Assets/ScriptableObject/ItemData.cs.meta
+++ b/Assets/ScriptableObject/ItemData.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: accb6e6eb81130345aba374b659bd151

--- a/Assets/ScriptableObject/ItmeData.asset
+++ b/Assets/ScriptableObject/ItmeData.asset
@@ -1,0 +1,15 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 0}
+  m_Name: ItmeData
+  m_EditorClassIdentifier: Assembly-CSharp::ItmeData
+  itemDataModels: []

--- a/Assets/ScriptableObject/ItmeData.asset.meta
+++ b/Assets/ScriptableObject/ItmeData.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: fc51c10b1773fd043ac72562d04d3729
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
+ 스킬은 이슈로 분리 했음
[아이템 스크립터블 구조 클래스 생성]
[구조 클래스 수정 및 아이템 데이터 내용 추가]

- `ItemDataModel` 및 `ItemEffetModel` 구조체를 정의하여 아이템의 기본 정보와 효과를 명확하게 구분합니다.
- `[Flags]` 어트리뷰트를 사용한 `FlagPatterns`, `FlagSymbols` 열거형을 도입하여, 하나의 효과가 여러 심볼이나 패턴에 동시에 적용될 수 있도록 확장성을 확보했습니다.
- `ItmeData` ScriptableObject를 생성하여 Unity 에디터 내에서 아이템 데이터베이스를 쉽게 생성하고 관리할 수 있는 기반을 마련했습니다.

<img width="303" height="671" alt="image" src="https://github.com/user-attachments/assets/459c4f97-eac2-489e-9557-4a28990c0fbc" />
