### PR TITLE
111 levelmanager 클래스 만들기

### DIFF
--- a/Assets/Prefabs/Doorway.prefab
+++ b/Assets/Prefabs/Doorway.prefab
@@ -87,6 +87,37 @@ MeshRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 0
   m_AdditionalVertexStreams: {fileID: 0}
+--- !u!1 &3047398551946958325
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6759653167811101671}
+  m_Layer: 6
+  m_Name: KeySpawnPoint
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6759653167811101671
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3047398551946958325}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0.009, y: 0.008, z: 0.02577}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 5886297503524352677}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &5389265913103211484
 GameObject:
   m_ObjectHideFlags: 0
@@ -102,6 +133,7 @@ GameObject:
   - component: {fileID: 3265840244197803091}
   - component: {fileID: 33416811221130813}
   - component: {fileID: 1437970684881750985}
+  - component: {fileID: 4406269088958431164}
   m_Layer: 6
   m_Name: Door
   m_TagString: Interactable
@@ -121,7 +153,8 @@ Transform:
   m_LocalPosition: {x: 0.000281, y: -0, z: 0.000661}
   m_LocalScale: {x: 0.255, y: 0.25000012, z: 0.23529428}
   m_ConstrainProportionsScale: 0
-  m_Children: []
+  m_Children:
+  - {fileID: 6759653167811101671}
   m_Father: {fileID: 3722292063726849807}
   m_LocalEulerAnglesHint: {x: -90, y: 0, z: 0}
 --- !u!33 &7288035618936686347
@@ -254,3 +287,18 @@ MonoBehaviour:
   precomputeOutline: 0
   bakeKeys: []
   bakeValues: []
+--- !u!114 &4406269088958431164
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5389265913103211484}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0338860f622ec0148b7ef7309630c76b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  keyPrefab: {fileID: 0}
+  spawnPoint: {fileID: 6759653167811101671}
+  targetLevel: 2

--- a/Assets/Prefabs/GameManager.prefab
+++ b/Assets/Prefabs/GameManager.prefab
@@ -108,3 +108,6 @@ MonoBehaviour:
     - {fileID: 1126586740, guid: 74422c0252b154445aaf19b2af62d406, type: 3}
     - {fileID: -465466833, guid: 74422c0252b154445aaf19b2af62d406, type: 3}
     - {fileID: 1515343977, guid: 74422c0252b154445aaf19b2af62d406, type: 3}
+  - symbol: 8
+    sprites:
+    - {fileID: 21300000, guid: 881908c32805fd14884363a8ebbafaf2, type: 3}

--- a/Assets/Prefabs/GameManager.prefab
+++ b/Assets/Prefabs/GameManager.prefab
@@ -11,6 +11,7 @@ GameObject:
   - component: {fileID: 2408568988708810262}
   - component: {fileID: 672508193366335186}
   - component: {fileID: 954389539016210305}
+  - component: {fileID: 2227944795136890753}
   m_Layer: 0
   m_Name: GameManager
   m_TagString: Untagged
@@ -111,3 +112,15 @@ MonoBehaviour:
   - symbol: 8
     sprites:
     - {fileID: 21300000, guid: 881908c32805fd14884363a8ebbafaf2, type: 3}
+--- !u!114 &2227944795136890753
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5919632821241984215}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5e3c8661294964e49800dbab37cd398e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Assets/Prefabs/Key.prefab
+++ b/Assets/Prefabs/Key.prefab
@@ -1,0 +1,144 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &4702292506888140698
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 27933675974785757}
+  - component: {fileID: 1080879215346457398}
+  - component: {fileID: 8269344277747825113}
+  - component: {fileID: 5184024104842814486}
+  - component: {fileID: 7707116582692576900}
+  - component: {fileID: 7243507005235807468}
+  m_Layer: 6
+  m_Name: Key
+  m_TagString: Interactable
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &27933675974785757
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4702292506888140698}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 3.3, y: 1.55, z: 1.94}
+  m_LocalScale: {x: 0.05, y: 0.05, z: 0.05}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &1080879215346457398
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4702292506888140698}
+  m_Mesh: {fileID: 10206, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &8269344277747825113
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4702292506888140698}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 31321ba15b8f8eb4c954353edc038b1d, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!136 &5184024104842814486
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4702292506888140698}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Radius: 0.5000001
+  m_Height: 2
+  m_Direction: 1
+  m_Center: {x: 0.000000059604645, y: 0, z: -0.00000008940697}
+--- !u!114 &7707116582692576900
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4702292506888140698}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e00e09a48e8a87340be7acd9ed84861d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &7243507005235807468
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4702292506888140698}
+  m_Enabled: 0
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5fea29bb7c508c244a1f805a5fd3fc4d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  outlineMode: 0
+  outlineColor: {r: 1, g: 0.92156863, b: 0.015686275, a: 1}
+  outlineWidth: 10
+  precomputeOutline: 0
+  bakeKeys: []
+  bakeValues: []

--- a/Assets/Prefabs/Key.prefab.meta
+++ b/Assets/Prefabs/Key.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: c19c588feb39d7c4dbf30be65012fbbe
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/MainScene.unity
+++ b/Assets/Scenes/MainScene.unity
@@ -127,6 +127,10 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 1170576051356645374, guid: e9e6087e900be2f40b41bd299c6341b3, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 2649308893299597789, guid: e9e6087e900be2f40b41bd299c6341b3, type: 3}
       propertyPath: m_Name
       value: Player
@@ -1084,6 +1088,17 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 3781d9cbfa3180f459531695abb39ed8, type: 3}
+--- !u!114 &934540370 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 9201742927471348575, guid: 3781d9cbfa3180f459531695abb39ed8, type: 3}
+  m_PrefabInstance: {fileID: 934540369}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1d2663fd446eebc41b3ca745f13bd505, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &955634121
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1976,6 +1991,14 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 9201742927471348575, guid: 3781d9cbfa3180f459531695abb39ed8, type: 3}
+      propertyPath: OnInteracted.m_PersistentCalls.m_Calls.Array.size
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9201742927471348575, guid: 3781d9cbfa3180f459531695abb39ed8, type: 3}
+      propertyPath: OnInteracted.m_PersistentCalls.m_Calls.Array.data[0].m_CallState
+      value: 2
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
@@ -2189,6 +2212,14 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 75748916176529756, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: doorLock
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 75748916176529756, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: lockTrigger
+      value: 
+      objectReference: {fileID: 934540370}
     - target: {fileID: 299687011269397420, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
@@ -2230,17 +2261,7337 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1002677006367515837, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: doorLock
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1002677006367515837, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
       propertyPath: lockTrigger
       value: 
       objectReference: {fileID: 921297460}
     - target: {fileID: 1280054278568004822, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: doorLock
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1280054278568004822, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
       propertyPath: lockTrigger
       value: 
       objectReference: {fileID: 921297460}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: precomputeOutline
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeKeys.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: 'bakeKeys.Array.data[0]'
+      value: 
+      objectReference: {fileID: 2974276771050408741, guid: d843ce5db252b30488f63e3865fb3aad, type: 3}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.size
+      value: 304
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[0].x
+      value: -0.70710677
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[0].z
+      value: -0.70710677
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[1].x
+      value: -0.57735026
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[1].y
+      value: -0.57735026
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[1].z
+      value: -0.57735026
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[2].x
+      value: -0.57735026
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[2].y
+      value: -0.57735026
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[2].z
+      value: 0.57735026
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[3].x
+      value: -0.70710677
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[3].z
+      value: 0.70710677
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[4].x
+      value: -0.57735026
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[4].y
+      value: 0.57735026
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[4].z
+      value: 0.57735026
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[5].x
+      value: -0.57735026
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[5].y
+      value: 0.57735026
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[5].z
+      value: -0.57735026
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[6].x
+      value: 0.70710677
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[6].z
+      value: -0.70710677
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[7].x
+      value: 0.57735026
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[7].y
+      value: -0.57735026
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[7].z
+      value: -0.57735026
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[8].x
+      value: -0.57735026
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[8].y
+      value: -0.57735026
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[8].z
+      value: -0.57735026
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[9].x
+      value: -0.70710677
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[9].z
+      value: -0.70710677
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[10].x
+      value: -0.57735026
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[10].y
+      value: 0.57735026
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[10].z
+      value: -0.57735026
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[11].x
+      value: 0.57735026
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[11].y
+      value: 0.57735026
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[11].z
+      value: -0.57735026
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[12].x
+      value: -0.70710677
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[12].z
+      value: 0.70710677
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[13].x
+      value: -0.57735026
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[13].y
+      value: -0.57735026
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[13].z
+      value: 0.57735026
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[14].x
+      value: 0.57735026
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[14].y
+      value: -0.57735026
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[14].z
+      value: 0.57735026
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[15].x
+      value: 0.70710677
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[15].z
+      value: 0.70710677
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[16].x
+      value: 0.57735026
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[16].y
+      value: 0.57735026
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[16].z
+      value: 0.57735026
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[17].x
+      value: -0.57735026
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[17].y
+      value: 0.57735026
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[17].z
+      value: 0.57735026
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[18].x
+      value: 0.24505597
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[18].y
+      value: -0.9330911
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[18].z
+      value: -0.26322728
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[19].x
+      value: 0.24505597
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[19].y
+      value: -0.9330911
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[19].z
+      value: -0.26322728
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[20].x
+      value: -0.24505658
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[20].y
+      value: -0.93309087
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[20].z
+      value: -0.26322737
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[21].x
+      value: -0.24505658
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[21].y
+      value: -0.93309087
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[21].z
+      value: -0.26322737
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[22].x
+      value: 0.24505578
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[22].y
+      value: -0.9330915
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[22].z
+      value: 0.2632259
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[23].x
+      value: 0.24505578
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[23].y
+      value: -0.9330915
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[23].z
+      value: 0.2632259
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[24].x
+      value: 0.24505597
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[24].y
+      value: -0.9330911
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[24].z
+      value: -0.26322728
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[25].x
+      value: 0.24505597
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[25].y
+      value: -0.9330911
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[25].z
+      value: -0.26322728
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[26].x
+      value: 0.57735026
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[26].y
+      value: -0.57735026
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[26].z
+      value: 0.57735026
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[27].x
+      value: 0.57735026
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[27].y
+      value: -0.57735026
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[27].z
+      value: -0.57735026
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[28].x
+      value: 0.70710677
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[28].z
+      value: -0.70710677
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[29].x
+      value: 0.70710677
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[29].z
+      value: 0.70710677
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[30].x
+      value: 0.57735026
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[30].y
+      value: 0.57735026
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[30].z
+      value: 0.57735026
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[31].x
+      value: 0.57735026
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[31].y
+      value: 0.57735026
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[31].z
+      value: -0.57735026
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[32].x
+      value: -0.24505658
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[32].y
+      value: -0.93309087
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[32].z
+      value: -0.26322737
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[33].x
+      value: -0.24505658
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[33].y
+      value: -0.93309087
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[33].z
+      value: -0.26322737
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[34].x
+      value: -0.24505638
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[34].y
+      value: -0.9330913
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[34].z
+      value: 0.26322597
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[35].x
+      value: -0.24505638
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[35].y
+      value: -0.9330913
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[35].z
+      value: 0.26322597
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[36].x
+      value: -0.24505658
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[36].y
+      value: -0.93309087
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[36].z
+      value: -0.26322737
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[37].x
+      value: 0.24505597
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[37].y
+      value: -0.9330911
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[37].z
+      value: -0.26322728
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[38].x
+      value: 0.24505578
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[38].y
+      value: -0.9330915
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[38].z
+      value: 0.2632259
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[39].x
+      value: -0.24505638
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[39].y
+      value: -0.9330913
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[39].z
+      value: 0.26322597
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[40].x
+      value: -0.24505638
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[40].y
+      value: -0.9330913
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[40].z
+      value: 0.26322597
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[41].x
+      value: -0.24505638
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[41].y
+      value: -0.9330913
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[41].z
+      value: 0.26322597
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[42].x
+      value: 0.24505578
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[42].y
+      value: -0.9330915
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[42].z
+      value: 0.2632259
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[43].x
+      value: 0.24505578
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[43].y
+      value: -0.9330915
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[43].z
+      value: 0.2632259
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[44].x
+      value: 0.24505572
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[44].y
+      value: 0.93309116
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[44].z
+      value: -0.2632273
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[45].x
+      value: -0.2450566
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[45].y
+      value: 0.93309087
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[45].z
+      value: -0.26322743
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[46].x
+      value: -0.2450566
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[46].y
+      value: 0.93309087
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[46].z
+      value: -0.26322743
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[47].x
+      value: 0.24505572
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[47].y
+      value: 0.93309116
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[47].z
+      value: -0.2632273
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[48].x
+      value: 0.24505553
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[48].y
+      value: 0.9330916
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[48].z
+      value: 0.26322588
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[49].x
+      value: 0.24505572
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[49].y
+      value: 0.93309116
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[49].z
+      value: -0.2632273
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[50].x
+      value: 0.24505572
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[50].y
+      value: 0.93309116
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[50].z
+      value: -0.2632273
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[51].x
+      value: 0.24505553
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[51].y
+      value: 0.9330916
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[51].z
+      value: 0.26322588
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[52].x
+      value: -0.2450566
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[52].y
+      value: 0.93309087
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[52].z
+      value: -0.26322743
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[53].x
+      value: -0.24505638
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[53].y
+      value: 0.9330913
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[53].z
+      value: 0.26322597
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[54].x
+      value: -0.24505638
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[54].y
+      value: 0.9330913
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[54].z
+      value: 0.26322597
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[55].x
+      value: -0.2450566
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[55].y
+      value: 0.93309087
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[55].z
+      value: -0.26322743
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[56].x
+      value: -0.2450566
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[56].y
+      value: 0.93309087
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[56].z
+      value: -0.26322743
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[57].x
+      value: -0.24505638
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[57].y
+      value: 0.9330913
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[57].z
+      value: 0.26322597
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[58].x
+      value: 0.24505553
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[58].y
+      value: 0.9330916
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[58].z
+      value: 0.26322588
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[59].x
+      value: 0.24505572
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[59].y
+      value: 0.93309116
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[59].z
+      value: -0.2632273
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[60].x
+      value: -0.24505638
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[60].y
+      value: 0.9330913
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[60].z
+      value: 0.26322597
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[61].x
+      value: 0.24505553
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[61].y
+      value: 0.9330916
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[61].z
+      value: 0.26322588
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[62].x
+      value: 0.24505553
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[62].y
+      value: 0.9330916
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[62].z
+      value: 0.26322588
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[63].x
+      value: -0.24505638
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[63].y
+      value: 0.9330913
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[63].z
+      value: 0.26322597
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[64].x
+      value: -0.57735026
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[64].y
+      value: 0.57735026
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[64].z
+      value: -0.57735026
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[65].x
+      value: -0.24505638
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[65].y
+      value: 0.9330913
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[65].z
+      value: 0.26322597
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[66].x
+      value: -0.2450566
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[66].y
+      value: 0.93309087
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[66].z
+      value: -0.26322743
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[67].x
+      value: -0.57735026
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[67].y
+      value: 0.57735026
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[67].z
+      value: 0.57735026
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[68].x
+      value: 0.57735026
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[68].y
+      value: 0.57735026
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[68].z
+      value: -0.57735026
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[69].x
+      value: 0.24505553
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[69].y
+      value: 0.9330916
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[69].z
+      value: 0.26322588
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[70].x
+      value: 0.24505572
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[70].y
+      value: 0.93309116
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[70].z
+      value: -0.2632273
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[71].x
+      value: 0.57735026
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[71].y
+      value: 0.57735026
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[71].z
+      value: 0.57735026
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[72].x
+      value: -0.57735026
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[72].y
+      value: -0.57735026
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[72].z
+      value: -0.57735026
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[73].x
+      value: -0.24505658
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[73].y
+      value: -0.93309087
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[73].z
+      value: -0.26322737
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[74].x
+      value: -0.24505638
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[74].y
+      value: -0.9330913
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[74].z
+      value: 0.26322597
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[75].x
+      value: -0.57735026
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[75].y
+      value: -0.57735026
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[75].z
+      value: 0.57735026
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[76].x
+      value: 0.57735026
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[76].y
+      value: -0.57735026
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[76].z
+      value: -0.57735026
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[77].x
+      value: 0.24505578
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[77].y
+      value: -0.9330915
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[77].z
+      value: 0.2632259
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[78].x
+      value: 0.24505597
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[78].y
+      value: -0.9330911
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[78].z
+      value: -0.26322728
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[79].x
+      value: 0.57735026
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[79].y
+      value: -0.57735026
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[79].z
+      value: 0.57735026
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[80].x
+      value: -0.00000029768506
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[80].y
+      value: -0.04941742
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[80].z
+      value: -0.9987782
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[81].x
+      value: -0.70624214
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[81].y
+      value: -0.04941804
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[81].z
+      value: -0.70624346
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[82].x
+      value: -0.68158215
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[82].y
+      value: -0.26624963
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[82].z
+      value: -0.6815841
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[83].x
+      value: 0.00000055535764
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[83].y
+      value: -0.26625034
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[83].z
+      value: -0.9639039
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[84].x
+      value: -0.70624214
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[84].y
+      value: -0.04941804
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[84].z
+      value: -0.70624346
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[85].x
+      value: -0.9987781
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[85].y
+      value: -0.049419183
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[85].z
+      value: -0.000000233895
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[86].x
+      value: -0.9639043
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[86].y
+      value: -0.26624897
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[86].z
+      value: 0.00000010256583
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[87].x
+      value: -0.68158215
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[87].y
+      value: -0.26624963
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[87].z
+      value: -0.6815841
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[88].x
+      value: -0.9987781
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[88].y
+      value: -0.049419183
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[88].z
+      value: -0.000000233895
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[89].x
+      value: -0.7062437
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[89].y
+      value: -0.049419798
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[89].z
+      value: 0.70624185
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[90].x
+      value: -0.6815832
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[90].y
+      value: -0.2662492
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[90].z
+      value: 0.6815832
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[91].x
+      value: -0.9639043
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[91].y
+      value: -0.26624897
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[91].z
+      value: 0.00000010256583
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[92].x
+      value: -0.7062437
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[92].y
+      value: -0.049419798
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[92].z
+      value: 0.70624185
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[93].x
+      value: -0.0000012864241
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[93].y
+      value: -0.049419522
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[93].z
+      value: 0.9987781
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[94].x
+      value: -0.0000010252764
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[94].y
+      value: -0.26625028
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[94].z
+      value: 0.96390396
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[95].x
+      value: -0.6815832
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[95].y
+      value: -0.2662492
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[95].z
+      value: 0.6815832
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[96].x
+      value: -0.0000012864241
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[96].y
+      value: -0.049419522
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[96].z
+      value: 0.9987781
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[97].x
+      value: 0.7062434
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[97].y
+      value: -0.049418718
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[97].z
+      value: 0.70624226
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[98].x
+      value: 0.6815831
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[98].y
+      value: -0.26625052
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[98].z
+      value: 0.68158287
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[99].x
+      value: -0.0000010252764
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[99].y
+      value: -0.26625028
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[99].z
+      value: 0.96390396
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[100].x
+      value: 0.7062434
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[100].y
+      value: -0.049418718
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[100].z
+      value: 0.70624226
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[101].x
+      value: 0.9987782
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[101].y
+      value: -0.04941793
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[101].z
+      value: -0.00000062726497
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[102].x
+      value: 0.963904
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[102].y
+      value: -0.26625004
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[102].z
+      value: -0.00000032039887
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[103].x
+      value: 0.6815831
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[103].y
+      value: -0.26625052
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[103].z
+      value: 0.68158287
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[104].x
+      value: 0.6815822
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[104].y
+      value: -0.26625127
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[104].z
+      value: -0.6815834
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[105].x
+      value: 0.00000055535764
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[105].y
+      value: -0.26625034
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[105].z
+      value: -0.9639039
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[106].x
+      value: -0.68158215
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[106].y
+      value: -0.26624963
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[106].z
+      value: -0.6815841
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[107].x
+      value: -0.9639043
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[107].y
+      value: -0.26624897
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[107].z
+      value: 0.00000010256583
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[108].x
+      value: 0.963904
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[108].y
+      value: -0.26625004
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[108].z
+      value: -0.00000032039887
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[109].x
+      value: 0.6815831
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[109].y
+      value: -0.26625052
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[109].z
+      value: 0.68158287
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[110].x
+      value: -0.6815832
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[110].y
+      value: -0.2662492
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[110].z
+      value: 0.6815832
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[111].x
+      value: -0.0000010252764
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[111].y
+      value: -0.26625028
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[111].z
+      value: 0.96390396
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[112].x
+      value: 0.9987782
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[112].y
+      value: -0.04941793
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[112].z
+      value: -0.00000062726497
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[113].x
+      value: 0.70624185
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[113].y
+      value: -0.049417585
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[113].z
+      value: -0.7062438
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[114].x
+      value: 0.6815822
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[114].y
+      value: -0.26625127
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[114].z
+      value: -0.6815834
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[115].x
+      value: 0.963904
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[115].y
+      value: -0.26625004
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[115].z
+      value: -0.00000032039887
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[116].x
+      value: 0.70624185
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[116].y
+      value: -0.049417585
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[116].z
+      value: -0.7062438
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[117].x
+      value: -0.00000029768506
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[117].y
+      value: -0.04941742
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[117].z
+      value: -0.9987782
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[118].x
+      value: 0.00000055535764
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[118].y
+      value: -0.26625034
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[118].z
+      value: -0.9639039
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[119].x
+      value: 0.6815822
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[119].y
+      value: -0.26625127
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[119].z
+      value: -0.6815834
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[120].x
+      value: 0.7062434
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[120].y
+      value: -0.049418718
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[120].z
+      value: 0.70624226
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[121].x
+      value: 0.7041061
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[121].y
+      value: 0.09202883
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[121].z
+      value: 0.70410603
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[122].x
+      value: 0.9957562
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[122].y
+      value: 0.09202981
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[122].z
+      value: -0.00000005777622
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[123].x
+      value: 0.9987782
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[123].y
+      value: -0.04941793
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[123].z
+      value: -0.00000062726497
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[124].x
+      value: -0.70410717
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[124].y
+      value: 0.09202764
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[124].z
+      value: 0.70410514
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[125].x
+      value: -0.45325303
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[125].y
+      value: -0.7675439
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[125].z
+      value: 0.45325264
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[126].x
+      value: -0.00000079844466
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[126].y
+      value: -0.767544
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[126].z
+      value: 0.6409963
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[127].x
+      value: -0.0000013577402
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[127].y
+      value: 0.09202901
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[127].z
+      value: 0.9957563
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[128].x
+      value: -0.7062437
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[128].y
+      value: -0.049419798
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[128].z
+      value: 0.70624185
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[129].x
+      value: -0.70410717
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[129].y
+      value: 0.09202764
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[129].z
+      value: 0.70410514
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[130].x
+      value: -0.0000013577402
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[130].y
+      value: 0.09202901
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[130].z
+      value: 0.9957563
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[131].x
+      value: -0.0000012864241
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[131].y
+      value: -0.049419522
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[131].z
+      value: 0.9987781
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[132].x
+      value: 0.9987782
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[132].y
+      value: -0.04941793
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[132].z
+      value: -0.00000062726497
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[133].x
+      value: 0.9957562
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[133].y
+      value: 0.09202981
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[133].z
+      value: -0.00000005777622
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[134].x
+      value: 0.70410544
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[134].y
+      value: 0.09203033
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[134].z
+      value: -0.70410645
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[135].x
+      value: 0.70624185
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[135].y
+      value: -0.049417585
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[135].z
+      value: -0.7062438
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[136].x
+      value: -0.70624214
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[136].y
+      value: -0.04941804
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[136].z
+      value: -0.70624346
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[137].x
+      value: -0.70410657
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[137].y
+      value: 0.09202957
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[137].z
+      value: -0.7041055
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[138].x
+      value: -0.99575645
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[138].y
+      value: 0.09202785
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[138].z
+      value: 0.000000105922936
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[139].x
+      value: -0.9987781
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[139].y
+      value: -0.049419183
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[139].z
+      value: -0.000000233895
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[140].x
+      value: -0.0000012864241
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[140].y
+      value: -0.049419522
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[140].z
+      value: 0.9987781
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[141].x
+      value: -0.0000013577402
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[141].y
+      value: 0.09202901
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[141].z
+      value: 0.9957563
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[142].x
+      value: 0.7041061
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[142].y
+      value: 0.09202883
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[142].z
+      value: 0.70410603
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[143].x
+      value: 0.7062434
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[143].y
+      value: -0.049418718
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[143].z
+      value: 0.70624226
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[144].x
+      value: 0.70624185
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[144].y
+      value: -0.049417585
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[144].z
+      value: -0.7062438
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[145].x
+      value: 0.70410544
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[145].y
+      value: 0.09203033
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[145].z
+      value: -0.70410645
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[146].x
+      value: -0.0000011747835
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[146].y
+      value: 0.09202985
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[146].z
+      value: -0.9957562
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[147].x
+      value: -0.00000029768506
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[147].y
+      value: -0.04941742
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[147].z
+      value: -0.9987782
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[148].x
+      value: -0.00000029768506
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[148].y
+      value: -0.04941742
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[148].z
+      value: -0.9987782
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[149].x
+      value: -0.0000011747835
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[149].y
+      value: 0.09202985
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[149].z
+      value: -0.9957562
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[150].x
+      value: -0.70410657
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[150].y
+      value: 0.09202957
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[150].z
+      value: -0.7041055
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[151].x
+      value: -0.70624214
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[151].y
+      value: -0.04941804
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[151].z
+      value: -0.70624346
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[152].x
+      value: -0.9987781
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[152].y
+      value: -0.049419183
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[152].z
+      value: -0.000000233895
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[153].x
+      value: -0.99575645
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[153].y
+      value: 0.09202785
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[153].z
+      value: 0.000000105922936
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[154].x
+      value: -0.70410717
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[154].y
+      value: 0.09202764
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[154].z
+      value: 0.70410514
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[155].x
+      value: -0.7062437
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[155].y
+      value: -0.049419798
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[155].z
+      value: 0.70624185
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[156].x
+      value: -0.45325363
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[156].y
+      value: -0.767544
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[156].z
+      value: -0.45325193
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[157].x
+      value: -0.0000007984441
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[157].y
+      value: -0.767545
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[157].z
+      value: -0.64099514
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[158].x
+      value: 0.45325255
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[158].y
+      value: -0.76754445
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[158].z
+      value: -0.4532523
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[159].x
+      value: -0.6409958
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[159].y
+      value: -0.76754445
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[159].z
+      value: 0.00000044618938
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[160].x
+      value: 0.6409956
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[160].y
+      value: -0.76754445
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[160].z
+      value: 0.0000004461895
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[161].x
+      value: -0.45325303
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[161].y
+      value: -0.7675439
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[161].z
+      value: 0.45325264
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[162].x
+      value: 0.45325196
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[162].y
+      value: -0.7675443
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[162].z
+      value: 0.453253
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[163].x
+      value: -0.00000079844466
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[163].y
+      value: -0.767544
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[163].z
+      value: 0.6409963
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[164].x
+      value: -0.70410657
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[164].y
+      value: 0.09202957
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[164].z
+      value: -0.7041055
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[165].x
+      value: -0.45325363
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[165].y
+      value: -0.767544
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[165].z
+      value: -0.45325193
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[166].x
+      value: -0.6409958
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[166].y
+      value: -0.76754445
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[166].z
+      value: 0.00000044618938
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[167].x
+      value: -0.99575645
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[167].y
+      value: 0.09202785
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[167].z
+      value: 0.000000105922936
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[168].x
+      value: 0.9957562
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[168].y
+      value: 0.09202981
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[168].z
+      value: -0.00000005777622
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[169].x
+      value: 0.6409956
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[169].y
+      value: -0.76754445
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[169].z
+      value: 0.0000004461895
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[170].x
+      value: 0.45325255
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[170].y
+      value: -0.76754445
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[170].z
+      value: -0.4532523
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[171].x
+      value: 0.70410544
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[171].y
+      value: 0.09203033
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[171].z
+      value: -0.70410645
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[172].x
+      value: -0.0000013577402
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[172].y
+      value: 0.09202901
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[172].z
+      value: 0.9957563
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[173].x
+      value: -0.00000079844466
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[173].y
+      value: -0.767544
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[173].z
+      value: 0.6409963
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[174].x
+      value: 0.45325196
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[174].y
+      value: -0.7675443
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[174].z
+      value: 0.453253
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[175].x
+      value: 0.7041061
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[175].y
+      value: 0.09202883
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[175].z
+      value: 0.70410603
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[176].x
+      value: -0.99575645
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[176].y
+      value: 0.09202785
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[176].z
+      value: 0.000000105922936
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[177].x
+      value: -0.6409958
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[177].y
+      value: -0.76754445
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[177].z
+      value: 0.00000044618938
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[178].x
+      value: -0.45325303
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[178].y
+      value: -0.7675439
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[178].z
+      value: 0.45325264
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[179].x
+      value: -0.70410717
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[179].y
+      value: 0.09202764
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[179].z
+      value: 0.70410514
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[180].x
+      value: -0.0000011747835
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[180].y
+      value: 0.09202985
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[180].z
+      value: -0.9957562
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[181].x
+      value: -0.0000007984441
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[181].y
+      value: -0.767545
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[181].z
+      value: -0.64099514
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[182].x
+      value: -0.45325363
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[182].y
+      value: -0.767544
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[182].z
+      value: -0.45325193
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[183].x
+      value: -0.70410657
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[183].y
+      value: 0.09202957
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[183].z
+      value: -0.7041055
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[184].x
+      value: 0.70410544
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[184].y
+      value: 0.09203033
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[184].z
+      value: -0.70410645
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[185].x
+      value: 0.45325255
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[185].y
+      value: -0.76754445
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[185].z
+      value: -0.4532523
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[186].x
+      value: -0.0000007984441
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[186].y
+      value: -0.767545
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[186].z
+      value: -0.64099514
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[187].x
+      value: -0.0000011747835
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[187].y
+      value: 0.09202985
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[187].z
+      value: -0.9957562
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[188].x
+      value: 0.7041061
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[188].y
+      value: 0.09202883
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[188].z
+      value: 0.70410603
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[189].x
+      value: 0.45325196
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[189].y
+      value: -0.7675443
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[189].z
+      value: 0.453253
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[190].x
+      value: 0.6409956
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[190].y
+      value: -0.76754445
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[190].z
+      value: 0.0000004461895
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[191].x
+      value: 0.9957562
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[191].y
+      value: 0.09202981
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[191].z
+      value: -0.00000005777622
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[192].x
+      value: -0.00000020200055
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[192].y
+      value: 0.049417116
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[192].z
+      value: -0.9987782
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[193].x
+      value: 0.0000007475968
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[193].y
+      value: 0.26624972
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[193].z
+      value: -0.9639041
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[194].x
+      value: -0.6815824
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[194].y
+      value: 0.2662495
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[194].z
+      value: -0.681584
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[195].x
+      value: -0.70624226
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[195].y
+      value: 0.04941799
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[195].z
+      value: -0.7062434
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[196].x
+      value: -0.70624226
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[196].y
+      value: 0.04941799
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[196].z
+      value: -0.7062434
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[197].x
+      value: -0.6815824
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[197].y
+      value: 0.2662495
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[197].z
+      value: -0.681584
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[198].x
+      value: -0.9639043
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[198].y
+      value: 0.26624897
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[198].z
+      value: 0.000000118427735
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[199].x
+      value: -0.9987781
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[199].y
+      value: 0.049419183
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[199].z
+      value: -0.00000027642136
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[200].x
+      value: -0.9987781
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[200].y
+      value: 0.049419183
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[200].z
+      value: -0.00000027642136
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[201].x
+      value: -0.9639043
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[201].y
+      value: 0.26624897
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[201].z
+      value: 0.000000118427735
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[202].x
+      value: -0.6815833
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[202].y
+      value: 0.26624957
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[202].z
+      value: 0.6815829
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[203].x
+      value: -0.7062439
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[203].y
+      value: 0.049419973
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[203].z
+      value: 0.70624167
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[204].x
+      value: -0.7062439
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[204].y
+      value: 0.049419973
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[204].z
+      value: 0.70624167
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[205].x
+      value: -0.6815833
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[205].y
+      value: 0.26624957
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[205].z
+      value: 0.6815829
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[206].x
+      value: -0.0000008757574
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[206].y
+      value: 0.2662509
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[206].z
+      value: 0.9639038
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[207].x
+      value: -0.00000119074
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[207].y
+      value: 0.049419772
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[207].z
+      value: 0.9987781
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[208].x
+      value: -0.00000119074
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[208].y
+      value: 0.049419772
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[208].z
+      value: 0.9987781
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[209].x
+      value: -0.0000008757574
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[209].y
+      value: 0.2662509
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[209].z
+      value: 0.9639038
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[210].x
+      value: 0.6815832
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[210].y
+      value: 0.2662505
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[210].z
+      value: 0.6815827
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[211].x
+      value: 0.70624346
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[211].y
+      value: 0.049418736
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[211].z
+      value: 0.7062422
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[212].x
+      value: 0.70624346
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[212].y
+      value: 0.049418736
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[212].z
+      value: 0.7062422
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[213].x
+      value: 0.6815832
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[213].y
+      value: 0.2662505
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[213].z
+      value: 0.6815827
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[214].x
+      value: 0.963904
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[214].y
+      value: 0.26625004
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[214].z
+      value: -0.00000029903896
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[215].x
+      value: 0.9987782
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[215].y
+      value: 0.049417526
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[215].z
+      value: -0.00000036147483
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[216].x
+      value: -0.6815824
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[216].y
+      value: 0.2662495
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[216].z
+      value: -0.681584
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[217].x
+      value: 0.0000007475968
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[217].y
+      value: 0.26624972
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[217].z
+      value: -0.9639041
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[218].x
+      value: 0.68158245
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[218].y
+      value: 0.26625064
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[218].z
+      value: -0.68158346
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[219].x
+      value: -0.9639043
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[219].y
+      value: 0.26624897
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[219].z
+      value: 0.000000118427735
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[220].x
+      value: 0.963904
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[220].y
+      value: 0.26625004
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[220].z
+      value: -0.00000029903896
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[221].x
+      value: -0.6815833
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[221].y
+      value: 0.26624957
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[221].z
+      value: 0.6815829
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[222].x
+      value: 0.6815832
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[222].y
+      value: 0.2662505
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[222].z
+      value: 0.6815827
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[223].x
+      value: -0.0000008757574
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[223].y
+      value: 0.2662509
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[223].z
+      value: 0.9639038
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[224].x
+      value: 0.9987782
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[224].y
+      value: 0.049417526
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[224].z
+      value: -0.00000036147483
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[225].x
+      value: 0.963904
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[225].y
+      value: 0.26625004
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[225].z
+      value: -0.00000029903896
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[226].x
+      value: 0.68158245
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[226].y
+      value: 0.26625064
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[226].z
+      value: -0.68158346
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[227].x
+      value: 0.7062419
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[227].y
+      value: 0.049416866
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[227].z
+      value: -0.7062439
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[228].x
+      value: 0.7062419
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[228].y
+      value: 0.049416866
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[228].z
+      value: -0.7062439
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[229].x
+      value: 0.68158245
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[229].y
+      value: 0.26625064
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[229].z
+      value: -0.68158346
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[230].x
+      value: 0.0000007475968
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[230].y
+      value: 0.26624972
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[230].z
+      value: -0.9639041
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[231].x
+      value: -0.00000020200055
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[231].y
+      value: 0.049417116
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[231].z
+      value: -0.9987782
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[232].x
+      value: 0.70624346
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[232].y
+      value: 0.049418736
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[232].z
+      value: 0.7062422
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[233].x
+      value: 0.9987782
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[233].y
+      value: 0.049417526
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[233].z
+      value: -0.00000036147483
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[234].x
+      value: 0.9957562
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[234].y
+      value: -0.09202991
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[234].z
+      value: 0.00000024073435
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[235].x
+      value: 0.7041061
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[235].y
+      value: -0.09202878
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[235].z
+      value: 0.70410603
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[236].x
+      value: -0.7041072
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[236].y
+      value: -0.09202777
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[236].z
+      value: 0.7041051
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[237].x
+      value: -0.0000012999641
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[237].y
+      value: -0.092028864
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[237].z
+      value: 0.9957563
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[238].x
+      value: -0.0000007514773
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[238].y
+      value: 0.76754415
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[238].z
+      value: 0.6409961
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[239].x
+      value: -0.4532532
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[239].y
+      value: 0.76754385
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[239].z
+      value: 0.4532527
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[240].x
+      value: -0.7062439
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[240].y
+      value: 0.049419973
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[240].z
+      value: 0.70624167
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[241].x
+      value: -0.00000119074
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[241].y
+      value: 0.049419772
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[241].z
+      value: 0.9987781
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[242].x
+      value: -0.0000012999641
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[242].y
+      value: -0.092028864
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[242].z
+      value: 0.9957563
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[243].x
+      value: -0.7041072
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[243].y
+      value: -0.09202777
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[243].z
+      value: 0.7041051
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[244].x
+      value: 0.9987782
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[244].y
+      value: 0.049417526
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[244].z
+      value: -0.00000036147483
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[245].x
+      value: 0.7062419
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[245].y
+      value: 0.049416866
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[245].z
+      value: -0.7062439
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[246].x
+      value: 0.7041054
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[246].y
+      value: -0.09203016
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[246].z
+      value: -0.70410657
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[247].x
+      value: 0.9957562
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[247].y
+      value: -0.09202991
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[247].z
+      value: 0.00000024073435
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[248].x
+      value: -0.70624226
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[248].y
+      value: 0.04941799
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[248].z
+      value: -0.7062434
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[249].x
+      value: -0.9987781
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[249].y
+      value: 0.049419183
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[249].z
+      value: -0.00000027642136
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[250].x
+      value: -0.9957564
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[250].y
+      value: -0.09202814
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[250].z
+      value: 0.00000013481097
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[251].x
+      value: -0.70410657
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[251].y
+      value: -0.09202971
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[251].z
+      value: -0.70410544
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[252].x
+      value: -0.00000119074
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[252].y
+      value: 0.049419772
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[252].z
+      value: 0.9987781
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[253].x
+      value: 0.70624346
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[253].y
+      value: 0.049418736
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[253].z
+      value: 0.7062422
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[254].x
+      value: 0.7041061
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[254].y
+      value: -0.09202878
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[254].z
+      value: 0.70410603
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[255].x
+      value: -0.0000012999641
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[255].y
+      value: -0.092028864
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[255].z
+      value: 0.9957563
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[256].x
+      value: 0.7062419
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[256].y
+      value: 0.049416866
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[256].z
+      value: -0.7062439
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[257].x
+      value: -0.00000020200055
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[257].y
+      value: 0.049417116
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[257].z
+      value: -0.9987782
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[258].x
+      value: -0.0000012518188
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[258].y
+      value: -0.09202968
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[258].z
+      value: -0.99575627
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[259].x
+      value: 0.7041054
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[259].y
+      value: -0.09203016
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[259].z
+      value: -0.70410657
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[260].x
+      value: -0.00000020200055
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[260].y
+      value: 0.049417116
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[260].z
+      value: -0.9987782
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[261].x
+      value: -0.70624226
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[261].y
+      value: 0.04941799
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[261].z
+      value: -0.7062434
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[262].x
+      value: -0.70410657
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[262].y
+      value: -0.09202971
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[262].z
+      value: -0.70410544
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[263].x
+      value: -0.0000012518188
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[263].y
+      value: -0.09202968
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[263].z
+      value: -0.99575627
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[264].x
+      value: -0.9987781
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[264].y
+      value: 0.049419183
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[264].z
+      value: -0.00000027642136
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[265].x
+      value: -0.7062439
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[265].y
+      value: 0.049419973
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[265].z
+      value: 0.70624167
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[266].x
+      value: -0.7041072
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[266].y
+      value: -0.09202777
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[266].z
+      value: 0.7041051
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[267].x
+      value: -0.9957564
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[267].y
+      value: -0.09202814
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[267].z
+      value: 0.00000013481097
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[268].x
+      value: 0.4532521
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[268].y
+      value: 0.767545
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[268].z
+      value: -0.45325187
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[269].x
+      value: -0.0000008923785
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[269].y
+      value: 0.7675451
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[269].z
+      value: -0.6409949
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[270].x
+      value: -0.4532537
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[270].y
+      value: 0.76754385
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[270].z
+      value: -0.45325208
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[271].x
+      value: 0.6409953
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[271].y
+      value: 0.76754475
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[271].z
+      value: 0.0000005166404
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[272].x
+      value: -0.6409961
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[272].y
+      value: 0.76754415
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[272].z
+      value: 0.00000052838226
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[273].x
+      value: 0.45325196
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[273].y
+      value: 0.7675443
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[273].z
+      value: 0.453253
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[274].x
+      value: -0.4532532
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[274].y
+      value: 0.76754385
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[274].z
+      value: 0.4532527
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[275].x
+      value: -0.0000007514773
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[275].y
+      value: 0.76754415
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[275].z
+      value: 0.6409961
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[276].x
+      value: -0.70410657
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[276].y
+      value: -0.09202971
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[276].z
+      value: -0.70410544
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[277].x
+      value: -0.9957564
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[277].y
+      value: -0.09202814
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[277].z
+      value: 0.00000013481097
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[278].x
+      value: -0.6409961
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[278].y
+      value: 0.76754415
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[278].z
+      value: 0.00000052838226
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[279].x
+      value: -0.4532537
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[279].y
+      value: 0.76754385
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[279].z
+      value: -0.45325208
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[280].x
+      value: 0.9957562
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[280].y
+      value: -0.09202991
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[280].z
+      value: 0.00000024073435
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[281].x
+      value: 0.7041054
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[281].y
+      value: -0.09203016
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[281].z
+      value: -0.70410657
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[282].x
+      value: 0.4532521
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[282].y
+      value: 0.767545
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[282].z
+      value: -0.45325187
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[283].x
+      value: 0.6409953
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[283].y
+      value: 0.76754475
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[283].z
+      value: 0.0000005166404
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[284].x
+      value: -0.0000012999641
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[284].y
+      value: -0.092028864
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[284].z
+      value: 0.9957563
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[285].x
+      value: 0.7041061
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[285].y
+      value: -0.09202878
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[285].z
+      value: 0.70410603
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[286].x
+      value: 0.45325196
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[286].y
+      value: 0.7675443
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[286].z
+      value: 0.453253
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[287].x
+      value: -0.0000007514773
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[287].y
+      value: 0.76754415
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[287].z
+      value: 0.6409961
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[288].x
+      value: -0.9957564
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[288].y
+      value: -0.09202814
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[288].z
+      value: 0.00000013481097
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[289].x
+      value: -0.7041072
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[289].y
+      value: -0.09202777
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[289].z
+      value: 0.7041051
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[290].x
+      value: -0.4532532
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[290].y
+      value: 0.76754385
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[290].z
+      value: 0.4532527
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[291].x
+      value: -0.6409961
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[291].y
+      value: 0.76754415
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[291].z
+      value: 0.00000052838226
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[292].x
+      value: -0.0000012518188
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[292].y
+      value: -0.09202968
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[292].z
+      value: -0.99575627
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[293].x
+      value: -0.70410657
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[293].y
+      value: -0.09202971
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[293].z
+      value: -0.70410544
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[294].x
+      value: -0.4532537
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[294].y
+      value: 0.76754385
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[294].z
+      value: -0.45325208
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[295].x
+      value: -0.0000008923785
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[295].y
+      value: 0.7675451
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[295].z
+      value: -0.6409949
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[296].x
+      value: 0.7041054
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[296].y
+      value: -0.09203016
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[296].z
+      value: -0.70410657
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[297].x
+      value: -0.0000012518188
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[297].y
+      value: -0.09202968
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[297].z
+      value: -0.99575627
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[298].x
+      value: -0.0000008923785
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[298].y
+      value: 0.7675451
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[298].z
+      value: -0.6409949
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[299].x
+      value: 0.4532521
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[299].y
+      value: 0.767545
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[299].z
+      value: -0.45325187
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[300].x
+      value: 0.7041061
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[300].y
+      value: -0.09202878
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[300].z
+      value: 0.70410603
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[301].x
+      value: 0.9957562
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[301].y
+      value: -0.09202991
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[301].z
+      value: 0.00000024073435
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[302].x
+      value: 0.6409953
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[302].y
+      value: 0.76754475
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[302].z
+      value: 0.0000005166404
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[303].x
+      value: 0.45325196
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[303].y
+      value: 0.7675443
+      objectReference: {fileID: 0}
+    - target: {fileID: 2191058107494117705, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[303].z
+      value: 0.453253
+      objectReference: {fileID: 0}
+    - target: {fileID: 3211951195123477847, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: keyPrefab
+      value: 
+      objectReference: {fileID: 4702292506888140698, guid: c19c588feb39d7c4dbf30be65012fbbe, type: 3}
+    - target: {fileID: 3211951195123477847, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: targetLevel
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3511320488716977468, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: keyPrefab
+      value: 
+      objectReference: {fileID: 4702292506888140698, guid: c19c588feb39d7c4dbf30be65012fbbe, type: 3}
+    - target: {fileID: 3511320488716977468, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: targetLevel
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4349794655293442269, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: keyPrefab
+      value: 
+      objectReference: {fileID: 4702292506888140698, guid: c19c588feb39d7c4dbf30be65012fbbe, type: 3}
+    - target: {fileID: 4349794655293442269, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: targetLevel
+      value: 3
+      objectReference: {fileID: 0}
     - target: {fileID: 4989714910332864781, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
       propertyPath: m_Name
       value: Map
       objectReference: {fileID: 0}
+    - target: {fileID: 5192578156020198789, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: keyPrefab
+      value: 
+      objectReference: {fileID: 4702292506888140698, guid: c19c588feb39d7c4dbf30be65012fbbe, type: 3}
+    - target: {fileID: 5192578156020198789, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: targetLevel
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: precomputeOutline
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeKeys.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: 'bakeKeys.Array.data[0]'
+      value: 
+      objectReference: {fileID: 2974276771050408741, guid: d843ce5db252b30488f63e3865fb3aad, type: 3}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.size
+      value: 304
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[0].x
+      value: -0.70710677
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[0].z
+      value: -0.70710677
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[1].x
+      value: -0.57735026
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[1].y
+      value: -0.57735026
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[1].z
+      value: -0.57735026
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[2].x
+      value: -0.57735026
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[2].y
+      value: -0.57735026
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[2].z
+      value: 0.57735026
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[3].x
+      value: -0.70710677
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[3].z
+      value: 0.70710677
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[4].x
+      value: -0.57735026
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[4].y
+      value: 0.57735026
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[4].z
+      value: 0.57735026
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[5].x
+      value: -0.57735026
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[5].y
+      value: 0.57735026
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[5].z
+      value: -0.57735026
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[6].x
+      value: 0.70710677
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[6].z
+      value: -0.70710677
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[7].x
+      value: 0.57735026
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[7].y
+      value: -0.57735026
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[7].z
+      value: -0.57735026
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[8].x
+      value: -0.57735026
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[8].y
+      value: -0.57735026
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[8].z
+      value: -0.57735026
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[9].x
+      value: -0.70710677
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[9].z
+      value: -0.70710677
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[10].x
+      value: -0.57735026
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[10].y
+      value: 0.57735026
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[10].z
+      value: -0.57735026
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[11].x
+      value: 0.57735026
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[11].y
+      value: 0.57735026
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[11].z
+      value: -0.57735026
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[12].x
+      value: -0.70710677
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[12].z
+      value: 0.70710677
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[13].x
+      value: -0.57735026
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[13].y
+      value: -0.57735026
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[13].z
+      value: 0.57735026
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[14].x
+      value: 0.57735026
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[14].y
+      value: -0.57735026
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[14].z
+      value: 0.57735026
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[15].x
+      value: 0.70710677
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[15].z
+      value: 0.70710677
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[16].x
+      value: 0.57735026
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[16].y
+      value: 0.57735026
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[16].z
+      value: 0.57735026
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[17].x
+      value: -0.57735026
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[17].y
+      value: 0.57735026
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[17].z
+      value: 0.57735026
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[18].x
+      value: 0.24505597
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[18].y
+      value: -0.9330911
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[18].z
+      value: -0.26322728
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[19].x
+      value: 0.24505597
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[19].y
+      value: -0.9330911
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[19].z
+      value: -0.26322728
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[20].x
+      value: -0.24505658
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[20].y
+      value: -0.93309087
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[20].z
+      value: -0.26322737
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[21].x
+      value: -0.24505658
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[21].y
+      value: -0.93309087
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[21].z
+      value: -0.26322737
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[22].x
+      value: 0.24505578
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[22].y
+      value: -0.9330915
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[22].z
+      value: 0.2632259
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[23].x
+      value: 0.24505578
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[23].y
+      value: -0.9330915
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[23].z
+      value: 0.2632259
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[24].x
+      value: 0.24505597
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[24].y
+      value: -0.9330911
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[24].z
+      value: -0.26322728
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[25].x
+      value: 0.24505597
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[25].y
+      value: -0.9330911
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[25].z
+      value: -0.26322728
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[26].x
+      value: 0.57735026
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[26].y
+      value: -0.57735026
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[26].z
+      value: 0.57735026
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[27].x
+      value: 0.57735026
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[27].y
+      value: -0.57735026
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[27].z
+      value: -0.57735026
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[28].x
+      value: 0.70710677
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[28].z
+      value: -0.70710677
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[29].x
+      value: 0.70710677
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[29].z
+      value: 0.70710677
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[30].x
+      value: 0.57735026
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[30].y
+      value: 0.57735026
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[30].z
+      value: 0.57735026
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[31].x
+      value: 0.57735026
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[31].y
+      value: 0.57735026
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[31].z
+      value: -0.57735026
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[32].x
+      value: -0.24505658
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[32].y
+      value: -0.93309087
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[32].z
+      value: -0.26322737
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[33].x
+      value: -0.24505658
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[33].y
+      value: -0.93309087
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[33].z
+      value: -0.26322737
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[34].x
+      value: -0.24505638
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[34].y
+      value: -0.9330913
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[34].z
+      value: 0.26322597
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[35].x
+      value: -0.24505638
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[35].y
+      value: -0.9330913
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[35].z
+      value: 0.26322597
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[36].x
+      value: -0.24505658
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[36].y
+      value: -0.93309087
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[36].z
+      value: -0.26322737
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[37].x
+      value: 0.24505597
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[37].y
+      value: -0.9330911
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[37].z
+      value: -0.26322728
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[38].x
+      value: 0.24505578
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[38].y
+      value: -0.9330915
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[38].z
+      value: 0.2632259
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[39].x
+      value: -0.24505638
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[39].y
+      value: -0.9330913
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[39].z
+      value: 0.26322597
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[40].x
+      value: -0.24505638
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[40].y
+      value: -0.9330913
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[40].z
+      value: 0.26322597
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[41].x
+      value: -0.24505638
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[41].y
+      value: -0.9330913
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[41].z
+      value: 0.26322597
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[42].x
+      value: 0.24505578
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[42].y
+      value: -0.9330915
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[42].z
+      value: 0.2632259
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[43].x
+      value: 0.24505578
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[43].y
+      value: -0.9330915
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[43].z
+      value: 0.2632259
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[44].x
+      value: 0.24505572
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[44].y
+      value: 0.93309116
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[44].z
+      value: -0.2632273
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[45].x
+      value: -0.2450566
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[45].y
+      value: 0.93309087
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[45].z
+      value: -0.26322743
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[46].x
+      value: -0.2450566
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[46].y
+      value: 0.93309087
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[46].z
+      value: -0.26322743
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[47].x
+      value: 0.24505572
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[47].y
+      value: 0.93309116
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[47].z
+      value: -0.2632273
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[48].x
+      value: 0.24505553
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[48].y
+      value: 0.9330916
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[48].z
+      value: 0.26322588
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[49].x
+      value: 0.24505572
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[49].y
+      value: 0.93309116
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[49].z
+      value: -0.2632273
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[50].x
+      value: 0.24505572
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[50].y
+      value: 0.93309116
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[50].z
+      value: -0.2632273
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[51].x
+      value: 0.24505553
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[51].y
+      value: 0.9330916
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[51].z
+      value: 0.26322588
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[52].x
+      value: -0.2450566
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[52].y
+      value: 0.93309087
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[52].z
+      value: -0.26322743
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[53].x
+      value: -0.24505638
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[53].y
+      value: 0.9330913
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[53].z
+      value: 0.26322597
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[54].x
+      value: -0.24505638
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[54].y
+      value: 0.9330913
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[54].z
+      value: 0.26322597
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[55].x
+      value: -0.2450566
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[55].y
+      value: 0.93309087
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[55].z
+      value: -0.26322743
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[56].x
+      value: -0.2450566
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[56].y
+      value: 0.93309087
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[56].z
+      value: -0.26322743
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[57].x
+      value: -0.24505638
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[57].y
+      value: 0.9330913
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[57].z
+      value: 0.26322597
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[58].x
+      value: 0.24505553
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[58].y
+      value: 0.9330916
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[58].z
+      value: 0.26322588
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[59].x
+      value: 0.24505572
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[59].y
+      value: 0.93309116
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[59].z
+      value: -0.2632273
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[60].x
+      value: -0.24505638
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[60].y
+      value: 0.9330913
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[60].z
+      value: 0.26322597
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[61].x
+      value: 0.24505553
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[61].y
+      value: 0.9330916
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[61].z
+      value: 0.26322588
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[62].x
+      value: 0.24505553
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[62].y
+      value: 0.9330916
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[62].z
+      value: 0.26322588
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[63].x
+      value: -0.24505638
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[63].y
+      value: 0.9330913
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[63].z
+      value: 0.26322597
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[64].x
+      value: -0.57735026
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[64].y
+      value: 0.57735026
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[64].z
+      value: -0.57735026
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[65].x
+      value: -0.24505638
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[65].y
+      value: 0.9330913
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[65].z
+      value: 0.26322597
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[66].x
+      value: -0.2450566
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[66].y
+      value: 0.93309087
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[66].z
+      value: -0.26322743
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[67].x
+      value: -0.57735026
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[67].y
+      value: 0.57735026
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[67].z
+      value: 0.57735026
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[68].x
+      value: 0.57735026
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[68].y
+      value: 0.57735026
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[68].z
+      value: -0.57735026
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[69].x
+      value: 0.24505553
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[69].y
+      value: 0.9330916
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[69].z
+      value: 0.26322588
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[70].x
+      value: 0.24505572
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[70].y
+      value: 0.93309116
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[70].z
+      value: -0.2632273
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[71].x
+      value: 0.57735026
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[71].y
+      value: 0.57735026
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[71].z
+      value: 0.57735026
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[72].x
+      value: -0.57735026
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[72].y
+      value: -0.57735026
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[72].z
+      value: -0.57735026
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[73].x
+      value: -0.24505658
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[73].y
+      value: -0.93309087
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[73].z
+      value: -0.26322737
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[74].x
+      value: -0.24505638
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[74].y
+      value: -0.9330913
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[74].z
+      value: 0.26322597
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[75].x
+      value: -0.57735026
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[75].y
+      value: -0.57735026
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[75].z
+      value: 0.57735026
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[76].x
+      value: 0.57735026
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[76].y
+      value: -0.57735026
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[76].z
+      value: -0.57735026
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[77].x
+      value: 0.24505578
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[77].y
+      value: -0.9330915
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[77].z
+      value: 0.2632259
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[78].x
+      value: 0.24505597
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[78].y
+      value: -0.9330911
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[78].z
+      value: -0.26322728
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[79].x
+      value: 0.57735026
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[79].y
+      value: -0.57735026
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[79].z
+      value: 0.57735026
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[80].x
+      value: -0.00000029768506
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[80].y
+      value: -0.04941742
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[80].z
+      value: -0.9987782
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[81].x
+      value: -0.70624214
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[81].y
+      value: -0.04941804
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[81].z
+      value: -0.70624346
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[82].x
+      value: -0.68158215
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[82].y
+      value: -0.26624963
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[82].z
+      value: -0.6815841
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[83].x
+      value: 0.00000055535764
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[83].y
+      value: -0.26625034
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[83].z
+      value: -0.9639039
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[84].x
+      value: -0.70624214
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[84].y
+      value: -0.04941804
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[84].z
+      value: -0.70624346
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[85].x
+      value: -0.9987781
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[85].y
+      value: -0.049419183
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[85].z
+      value: -0.000000233895
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[86].x
+      value: -0.9639043
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[86].y
+      value: -0.26624897
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[86].z
+      value: 0.00000010256583
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[87].x
+      value: -0.68158215
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[87].y
+      value: -0.26624963
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[87].z
+      value: -0.6815841
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[88].x
+      value: -0.9987781
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[88].y
+      value: -0.049419183
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[88].z
+      value: -0.000000233895
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[89].x
+      value: -0.7062437
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[89].y
+      value: -0.049419798
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[89].z
+      value: 0.70624185
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[90].x
+      value: -0.6815832
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[90].y
+      value: -0.2662492
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[90].z
+      value: 0.6815832
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[91].x
+      value: -0.9639043
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[91].y
+      value: -0.26624897
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[91].z
+      value: 0.00000010256583
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[92].x
+      value: -0.7062437
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[92].y
+      value: -0.049419798
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[92].z
+      value: 0.70624185
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[93].x
+      value: -0.0000012864241
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[93].y
+      value: -0.049419522
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[93].z
+      value: 0.9987781
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[94].x
+      value: -0.0000010252764
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[94].y
+      value: -0.26625028
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[94].z
+      value: 0.96390396
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[95].x
+      value: -0.6815832
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[95].y
+      value: -0.2662492
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[95].z
+      value: 0.6815832
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[96].x
+      value: -0.0000012864241
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[96].y
+      value: -0.049419522
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[96].z
+      value: 0.9987781
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[97].x
+      value: 0.7062434
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[97].y
+      value: -0.049418718
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[97].z
+      value: 0.70624226
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[98].x
+      value: 0.6815831
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[98].y
+      value: -0.26625052
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[98].z
+      value: 0.68158287
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[99].x
+      value: -0.0000010252764
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[99].y
+      value: -0.26625028
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[99].z
+      value: 0.96390396
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[100].x
+      value: 0.7062434
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[100].y
+      value: -0.049418718
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[100].z
+      value: 0.70624226
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[101].x
+      value: 0.9987782
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[101].y
+      value: -0.04941793
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[101].z
+      value: -0.00000062726497
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[102].x
+      value: 0.963904
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[102].y
+      value: -0.26625004
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[102].z
+      value: -0.00000032039887
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[103].x
+      value: 0.6815831
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[103].y
+      value: -0.26625052
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[103].z
+      value: 0.68158287
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[104].x
+      value: 0.6815822
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[104].y
+      value: -0.26625127
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[104].z
+      value: -0.6815834
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[105].x
+      value: 0.00000055535764
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[105].y
+      value: -0.26625034
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[105].z
+      value: -0.9639039
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[106].x
+      value: -0.68158215
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[106].y
+      value: -0.26624963
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[106].z
+      value: -0.6815841
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[107].x
+      value: -0.9639043
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[107].y
+      value: -0.26624897
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[107].z
+      value: 0.00000010256583
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[108].x
+      value: 0.963904
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[108].y
+      value: -0.26625004
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[108].z
+      value: -0.00000032039887
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[109].x
+      value: 0.6815831
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[109].y
+      value: -0.26625052
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[109].z
+      value: 0.68158287
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[110].x
+      value: -0.6815832
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[110].y
+      value: -0.2662492
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[110].z
+      value: 0.6815832
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[111].x
+      value: -0.0000010252764
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[111].y
+      value: -0.26625028
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[111].z
+      value: 0.96390396
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[112].x
+      value: 0.9987782
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[112].y
+      value: -0.04941793
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[112].z
+      value: -0.00000062726497
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[113].x
+      value: 0.70624185
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[113].y
+      value: -0.049417585
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[113].z
+      value: -0.7062438
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[114].x
+      value: 0.6815822
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[114].y
+      value: -0.26625127
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[114].z
+      value: -0.6815834
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[115].x
+      value: 0.963904
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[115].y
+      value: -0.26625004
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[115].z
+      value: -0.00000032039887
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[116].x
+      value: 0.70624185
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[116].y
+      value: -0.049417585
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[116].z
+      value: -0.7062438
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[117].x
+      value: -0.00000029768506
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[117].y
+      value: -0.04941742
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[117].z
+      value: -0.9987782
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[118].x
+      value: 0.00000055535764
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[118].y
+      value: -0.26625034
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[118].z
+      value: -0.9639039
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[119].x
+      value: 0.6815822
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[119].y
+      value: -0.26625127
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[119].z
+      value: -0.6815834
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[120].x
+      value: 0.7062434
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[120].y
+      value: -0.049418718
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[120].z
+      value: 0.70624226
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[121].x
+      value: 0.7041061
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[121].y
+      value: 0.09202883
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[121].z
+      value: 0.70410603
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[122].x
+      value: 0.9957562
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[122].y
+      value: 0.09202981
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[122].z
+      value: -0.00000005777622
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[123].x
+      value: 0.9987782
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[123].y
+      value: -0.04941793
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[123].z
+      value: -0.00000062726497
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[124].x
+      value: -0.70410717
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[124].y
+      value: 0.09202764
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[124].z
+      value: 0.70410514
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[125].x
+      value: -0.45325303
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[125].y
+      value: -0.7675439
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[125].z
+      value: 0.45325264
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[126].x
+      value: -0.00000079844466
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[126].y
+      value: -0.767544
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[126].z
+      value: 0.6409963
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[127].x
+      value: -0.0000013577402
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[127].y
+      value: 0.09202901
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[127].z
+      value: 0.9957563
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[128].x
+      value: -0.7062437
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[128].y
+      value: -0.049419798
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[128].z
+      value: 0.70624185
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[129].x
+      value: -0.70410717
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[129].y
+      value: 0.09202764
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[129].z
+      value: 0.70410514
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[130].x
+      value: -0.0000013577402
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[130].y
+      value: 0.09202901
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[130].z
+      value: 0.9957563
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[131].x
+      value: -0.0000012864241
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[131].y
+      value: -0.049419522
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[131].z
+      value: 0.9987781
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[132].x
+      value: 0.9987782
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[132].y
+      value: -0.04941793
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[132].z
+      value: -0.00000062726497
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[133].x
+      value: 0.9957562
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[133].y
+      value: 0.09202981
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[133].z
+      value: -0.00000005777622
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[134].x
+      value: 0.70410544
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[134].y
+      value: 0.09203033
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[134].z
+      value: -0.70410645
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[135].x
+      value: 0.70624185
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[135].y
+      value: -0.049417585
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[135].z
+      value: -0.7062438
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[136].x
+      value: -0.70624214
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[136].y
+      value: -0.04941804
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[136].z
+      value: -0.70624346
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[137].x
+      value: -0.70410657
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[137].y
+      value: 0.09202957
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[137].z
+      value: -0.7041055
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[138].x
+      value: -0.99575645
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[138].y
+      value: 0.09202785
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[138].z
+      value: 0.000000105922936
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[139].x
+      value: -0.9987781
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[139].y
+      value: -0.049419183
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[139].z
+      value: -0.000000233895
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[140].x
+      value: -0.0000012864241
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[140].y
+      value: -0.049419522
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[140].z
+      value: 0.9987781
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[141].x
+      value: -0.0000013577402
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[141].y
+      value: 0.09202901
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[141].z
+      value: 0.9957563
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[142].x
+      value: 0.7041061
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[142].y
+      value: 0.09202883
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[142].z
+      value: 0.70410603
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[143].x
+      value: 0.7062434
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[143].y
+      value: -0.049418718
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[143].z
+      value: 0.70624226
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[144].x
+      value: 0.70624185
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[144].y
+      value: -0.049417585
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[144].z
+      value: -0.7062438
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[145].x
+      value: 0.70410544
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[145].y
+      value: 0.09203033
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[145].z
+      value: -0.70410645
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[146].x
+      value: -0.0000011747835
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[146].y
+      value: 0.09202985
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[146].z
+      value: -0.9957562
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[147].x
+      value: -0.00000029768506
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[147].y
+      value: -0.04941742
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[147].z
+      value: -0.9987782
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[148].x
+      value: -0.00000029768506
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[148].y
+      value: -0.04941742
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[148].z
+      value: -0.9987782
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[149].x
+      value: -0.0000011747835
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[149].y
+      value: 0.09202985
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[149].z
+      value: -0.9957562
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[150].x
+      value: -0.70410657
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[150].y
+      value: 0.09202957
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[150].z
+      value: -0.7041055
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[151].x
+      value: -0.70624214
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[151].y
+      value: -0.04941804
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[151].z
+      value: -0.70624346
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[152].x
+      value: -0.9987781
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[152].y
+      value: -0.049419183
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[152].z
+      value: -0.000000233895
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[153].x
+      value: -0.99575645
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[153].y
+      value: 0.09202785
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[153].z
+      value: 0.000000105922936
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[154].x
+      value: -0.70410717
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[154].y
+      value: 0.09202764
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[154].z
+      value: 0.70410514
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[155].x
+      value: -0.7062437
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[155].y
+      value: -0.049419798
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[155].z
+      value: 0.70624185
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[156].x
+      value: -0.45325363
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[156].y
+      value: -0.767544
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[156].z
+      value: -0.45325193
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[157].x
+      value: -0.0000007984441
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[157].y
+      value: -0.767545
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[157].z
+      value: -0.64099514
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[158].x
+      value: 0.45325255
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[158].y
+      value: -0.76754445
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[158].z
+      value: -0.4532523
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[159].x
+      value: -0.6409958
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[159].y
+      value: -0.76754445
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[159].z
+      value: 0.00000044618938
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[160].x
+      value: 0.6409956
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[160].y
+      value: -0.76754445
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[160].z
+      value: 0.0000004461895
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[161].x
+      value: -0.45325303
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[161].y
+      value: -0.7675439
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[161].z
+      value: 0.45325264
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[162].x
+      value: 0.45325196
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[162].y
+      value: -0.7675443
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[162].z
+      value: 0.453253
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[163].x
+      value: -0.00000079844466
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[163].y
+      value: -0.767544
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[163].z
+      value: 0.6409963
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[164].x
+      value: -0.70410657
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[164].y
+      value: 0.09202957
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[164].z
+      value: -0.7041055
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[165].x
+      value: -0.45325363
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[165].y
+      value: -0.767544
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[165].z
+      value: -0.45325193
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[166].x
+      value: -0.6409958
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[166].y
+      value: -0.76754445
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[166].z
+      value: 0.00000044618938
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[167].x
+      value: -0.99575645
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[167].y
+      value: 0.09202785
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[167].z
+      value: 0.000000105922936
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[168].x
+      value: 0.9957562
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[168].y
+      value: 0.09202981
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[168].z
+      value: -0.00000005777622
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[169].x
+      value: 0.6409956
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[169].y
+      value: -0.76754445
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[169].z
+      value: 0.0000004461895
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[170].x
+      value: 0.45325255
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[170].y
+      value: -0.76754445
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[170].z
+      value: -0.4532523
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[171].x
+      value: 0.70410544
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[171].y
+      value: 0.09203033
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[171].z
+      value: -0.70410645
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[172].x
+      value: -0.0000013577402
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[172].y
+      value: 0.09202901
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[172].z
+      value: 0.9957563
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[173].x
+      value: -0.00000079844466
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[173].y
+      value: -0.767544
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[173].z
+      value: 0.6409963
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[174].x
+      value: 0.45325196
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[174].y
+      value: -0.7675443
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[174].z
+      value: 0.453253
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[175].x
+      value: 0.7041061
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[175].y
+      value: 0.09202883
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[175].z
+      value: 0.70410603
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[176].x
+      value: -0.99575645
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[176].y
+      value: 0.09202785
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[176].z
+      value: 0.000000105922936
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[177].x
+      value: -0.6409958
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[177].y
+      value: -0.76754445
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[177].z
+      value: 0.00000044618938
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[178].x
+      value: -0.45325303
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[178].y
+      value: -0.7675439
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[178].z
+      value: 0.45325264
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[179].x
+      value: -0.70410717
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[179].y
+      value: 0.09202764
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[179].z
+      value: 0.70410514
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[180].x
+      value: -0.0000011747835
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[180].y
+      value: 0.09202985
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[180].z
+      value: -0.9957562
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[181].x
+      value: -0.0000007984441
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[181].y
+      value: -0.767545
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[181].z
+      value: -0.64099514
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[182].x
+      value: -0.45325363
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[182].y
+      value: -0.767544
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[182].z
+      value: -0.45325193
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[183].x
+      value: -0.70410657
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[183].y
+      value: 0.09202957
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[183].z
+      value: -0.7041055
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[184].x
+      value: 0.70410544
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[184].y
+      value: 0.09203033
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[184].z
+      value: -0.70410645
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[185].x
+      value: 0.45325255
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[185].y
+      value: -0.76754445
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[185].z
+      value: -0.4532523
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[186].x
+      value: -0.0000007984441
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[186].y
+      value: -0.767545
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[186].z
+      value: -0.64099514
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[187].x
+      value: -0.0000011747835
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[187].y
+      value: 0.09202985
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[187].z
+      value: -0.9957562
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[188].x
+      value: 0.7041061
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[188].y
+      value: 0.09202883
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[188].z
+      value: 0.70410603
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[189].x
+      value: 0.45325196
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[189].y
+      value: -0.7675443
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[189].z
+      value: 0.453253
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[190].x
+      value: 0.6409956
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[190].y
+      value: -0.76754445
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[190].z
+      value: 0.0000004461895
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[191].x
+      value: 0.9957562
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[191].y
+      value: 0.09202981
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[191].z
+      value: -0.00000005777622
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[192].x
+      value: -0.00000020200055
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[192].y
+      value: 0.049417116
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[192].z
+      value: -0.9987782
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[193].x
+      value: 0.0000007475968
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[193].y
+      value: 0.26624972
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[193].z
+      value: -0.9639041
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[194].x
+      value: -0.6815824
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[194].y
+      value: 0.2662495
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[194].z
+      value: -0.681584
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[195].x
+      value: -0.70624226
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[195].y
+      value: 0.04941799
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[195].z
+      value: -0.7062434
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[196].x
+      value: -0.70624226
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[196].y
+      value: 0.04941799
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[196].z
+      value: -0.7062434
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[197].x
+      value: -0.6815824
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[197].y
+      value: 0.2662495
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[197].z
+      value: -0.681584
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[198].x
+      value: -0.9639043
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[198].y
+      value: 0.26624897
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[198].z
+      value: 0.000000118427735
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[199].x
+      value: -0.9987781
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[199].y
+      value: 0.049419183
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[199].z
+      value: -0.00000027642136
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[200].x
+      value: -0.9987781
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[200].y
+      value: 0.049419183
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[200].z
+      value: -0.00000027642136
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[201].x
+      value: -0.9639043
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[201].y
+      value: 0.26624897
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[201].z
+      value: 0.000000118427735
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[202].x
+      value: -0.6815833
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[202].y
+      value: 0.26624957
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[202].z
+      value: 0.6815829
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[203].x
+      value: -0.7062439
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[203].y
+      value: 0.049419973
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[203].z
+      value: 0.70624167
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[204].x
+      value: -0.7062439
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[204].y
+      value: 0.049419973
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[204].z
+      value: 0.70624167
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[205].x
+      value: -0.6815833
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[205].y
+      value: 0.26624957
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[205].z
+      value: 0.6815829
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[206].x
+      value: -0.0000008757574
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[206].y
+      value: 0.2662509
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[206].z
+      value: 0.9639038
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[207].x
+      value: -0.00000119074
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[207].y
+      value: 0.049419772
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[207].z
+      value: 0.9987781
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[208].x
+      value: -0.00000119074
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[208].y
+      value: 0.049419772
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[208].z
+      value: 0.9987781
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[209].x
+      value: -0.0000008757574
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[209].y
+      value: 0.2662509
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[209].z
+      value: 0.9639038
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[210].x
+      value: 0.6815832
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[210].y
+      value: 0.2662505
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[210].z
+      value: 0.6815827
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[211].x
+      value: 0.70624346
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[211].y
+      value: 0.049418736
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[211].z
+      value: 0.7062422
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[212].x
+      value: 0.70624346
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[212].y
+      value: 0.049418736
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[212].z
+      value: 0.7062422
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[213].x
+      value: 0.6815832
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[213].y
+      value: 0.2662505
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[213].z
+      value: 0.6815827
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[214].x
+      value: 0.963904
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[214].y
+      value: 0.26625004
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[214].z
+      value: -0.00000029903896
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[215].x
+      value: 0.9987782
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[215].y
+      value: 0.049417526
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[215].z
+      value: -0.00000036147483
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[216].x
+      value: -0.6815824
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[216].y
+      value: 0.2662495
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[216].z
+      value: -0.681584
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[217].x
+      value: 0.0000007475968
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[217].y
+      value: 0.26624972
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[217].z
+      value: -0.9639041
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[218].x
+      value: 0.68158245
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[218].y
+      value: 0.26625064
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[218].z
+      value: -0.68158346
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[219].x
+      value: -0.9639043
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[219].y
+      value: 0.26624897
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[219].z
+      value: 0.000000118427735
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[220].x
+      value: 0.963904
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[220].y
+      value: 0.26625004
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[220].z
+      value: -0.00000029903896
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[221].x
+      value: -0.6815833
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[221].y
+      value: 0.26624957
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[221].z
+      value: 0.6815829
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[222].x
+      value: 0.6815832
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[222].y
+      value: 0.2662505
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[222].z
+      value: 0.6815827
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[223].x
+      value: -0.0000008757574
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[223].y
+      value: 0.2662509
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[223].z
+      value: 0.9639038
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[224].x
+      value: 0.9987782
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[224].y
+      value: 0.049417526
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[224].z
+      value: -0.00000036147483
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[225].x
+      value: 0.963904
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[225].y
+      value: 0.26625004
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[225].z
+      value: -0.00000029903896
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[226].x
+      value: 0.68158245
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[226].y
+      value: 0.26625064
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[226].z
+      value: -0.68158346
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[227].x
+      value: 0.7062419
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[227].y
+      value: 0.049416866
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[227].z
+      value: -0.7062439
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[228].x
+      value: 0.7062419
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[228].y
+      value: 0.049416866
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[228].z
+      value: -0.7062439
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[229].x
+      value: 0.68158245
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[229].y
+      value: 0.26625064
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[229].z
+      value: -0.68158346
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[230].x
+      value: 0.0000007475968
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[230].y
+      value: 0.26624972
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[230].z
+      value: -0.9639041
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[231].x
+      value: -0.00000020200055
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[231].y
+      value: 0.049417116
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[231].z
+      value: -0.9987782
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[232].x
+      value: 0.70624346
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[232].y
+      value: 0.049418736
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[232].z
+      value: 0.7062422
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[233].x
+      value: 0.9987782
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[233].y
+      value: 0.049417526
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[233].z
+      value: -0.00000036147483
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[234].x
+      value: 0.9957562
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[234].y
+      value: -0.09202991
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[234].z
+      value: 0.00000024073435
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[235].x
+      value: 0.7041061
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[235].y
+      value: -0.09202878
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[235].z
+      value: 0.70410603
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[236].x
+      value: -0.7041072
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[236].y
+      value: -0.09202777
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[236].z
+      value: 0.7041051
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[237].x
+      value: -0.0000012999641
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[237].y
+      value: -0.092028864
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[237].z
+      value: 0.9957563
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[238].x
+      value: -0.0000007514773
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[238].y
+      value: 0.76754415
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[238].z
+      value: 0.6409961
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[239].x
+      value: -0.4532532
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[239].y
+      value: 0.76754385
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[239].z
+      value: 0.4532527
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[240].x
+      value: -0.7062439
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[240].y
+      value: 0.049419973
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[240].z
+      value: 0.70624167
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[241].x
+      value: -0.00000119074
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[241].y
+      value: 0.049419772
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[241].z
+      value: 0.9987781
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[242].x
+      value: -0.0000012999641
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[242].y
+      value: -0.092028864
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[242].z
+      value: 0.9957563
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[243].x
+      value: -0.7041072
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[243].y
+      value: -0.09202777
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[243].z
+      value: 0.7041051
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[244].x
+      value: 0.9987782
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[244].y
+      value: 0.049417526
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[244].z
+      value: -0.00000036147483
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[245].x
+      value: 0.7062419
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[245].y
+      value: 0.049416866
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[245].z
+      value: -0.7062439
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[246].x
+      value: 0.7041054
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[246].y
+      value: -0.09203016
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[246].z
+      value: -0.70410657
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[247].x
+      value: 0.9957562
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[247].y
+      value: -0.09202991
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[247].z
+      value: 0.00000024073435
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[248].x
+      value: -0.70624226
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[248].y
+      value: 0.04941799
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[248].z
+      value: -0.7062434
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[249].x
+      value: -0.9987781
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[249].y
+      value: 0.049419183
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[249].z
+      value: -0.00000027642136
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[250].x
+      value: -0.9957564
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[250].y
+      value: -0.09202814
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[250].z
+      value: 0.00000013481097
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[251].x
+      value: -0.70410657
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[251].y
+      value: -0.09202971
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[251].z
+      value: -0.70410544
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[252].x
+      value: -0.00000119074
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[252].y
+      value: 0.049419772
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[252].z
+      value: 0.9987781
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[253].x
+      value: 0.70624346
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[253].y
+      value: 0.049418736
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[253].z
+      value: 0.7062422
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[254].x
+      value: 0.7041061
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[254].y
+      value: -0.09202878
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[254].z
+      value: 0.70410603
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[255].x
+      value: -0.0000012999641
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[255].y
+      value: -0.092028864
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[255].z
+      value: 0.9957563
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[256].x
+      value: 0.7062419
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[256].y
+      value: 0.049416866
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[256].z
+      value: -0.7062439
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[257].x
+      value: -0.00000020200055
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[257].y
+      value: 0.049417116
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[257].z
+      value: -0.9987782
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[258].x
+      value: -0.0000012518188
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[258].y
+      value: -0.09202968
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[258].z
+      value: -0.99575627
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[259].x
+      value: 0.7041054
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[259].y
+      value: -0.09203016
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[259].z
+      value: -0.70410657
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[260].x
+      value: -0.00000020200055
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[260].y
+      value: 0.049417116
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[260].z
+      value: -0.9987782
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[261].x
+      value: -0.70624226
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[261].y
+      value: 0.04941799
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[261].z
+      value: -0.7062434
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[262].x
+      value: -0.70410657
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[262].y
+      value: -0.09202971
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[262].z
+      value: -0.70410544
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[263].x
+      value: -0.0000012518188
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[263].y
+      value: -0.09202968
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[263].z
+      value: -0.99575627
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[264].x
+      value: -0.9987781
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[264].y
+      value: 0.049419183
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[264].z
+      value: -0.00000027642136
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[265].x
+      value: -0.7062439
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[265].y
+      value: 0.049419973
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[265].z
+      value: 0.70624167
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[266].x
+      value: -0.7041072
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[266].y
+      value: -0.09202777
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[266].z
+      value: 0.7041051
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[267].x
+      value: -0.9957564
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[267].y
+      value: -0.09202814
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[267].z
+      value: 0.00000013481097
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[268].x
+      value: 0.4532521
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[268].y
+      value: 0.767545
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[268].z
+      value: -0.45325187
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[269].x
+      value: -0.0000008923785
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[269].y
+      value: 0.7675451
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[269].z
+      value: -0.6409949
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[270].x
+      value: -0.4532537
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[270].y
+      value: 0.76754385
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[270].z
+      value: -0.45325208
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[271].x
+      value: 0.6409953
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[271].y
+      value: 0.76754475
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[271].z
+      value: 0.0000005166404
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[272].x
+      value: -0.6409961
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[272].y
+      value: 0.76754415
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[272].z
+      value: 0.00000052838226
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[273].x
+      value: 0.45325196
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[273].y
+      value: 0.7675443
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[273].z
+      value: 0.453253
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[274].x
+      value: -0.4532532
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[274].y
+      value: 0.76754385
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[274].z
+      value: 0.4532527
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[275].x
+      value: -0.0000007514773
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[275].y
+      value: 0.76754415
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[275].z
+      value: 0.6409961
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[276].x
+      value: -0.70410657
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[276].y
+      value: -0.09202971
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[276].z
+      value: -0.70410544
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[277].x
+      value: -0.9957564
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[277].y
+      value: -0.09202814
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[277].z
+      value: 0.00000013481097
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[278].x
+      value: -0.6409961
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[278].y
+      value: 0.76754415
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[278].z
+      value: 0.00000052838226
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[279].x
+      value: -0.4532537
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[279].y
+      value: 0.76754385
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[279].z
+      value: -0.45325208
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[280].x
+      value: 0.9957562
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[280].y
+      value: -0.09202991
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[280].z
+      value: 0.00000024073435
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[281].x
+      value: 0.7041054
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[281].y
+      value: -0.09203016
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[281].z
+      value: -0.70410657
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[282].x
+      value: 0.4532521
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[282].y
+      value: 0.767545
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[282].z
+      value: -0.45325187
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[283].x
+      value: 0.6409953
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[283].y
+      value: 0.76754475
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[283].z
+      value: 0.0000005166404
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[284].x
+      value: -0.0000012999641
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[284].y
+      value: -0.092028864
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[284].z
+      value: 0.9957563
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[285].x
+      value: 0.7041061
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[285].y
+      value: -0.09202878
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[285].z
+      value: 0.70410603
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[286].x
+      value: 0.45325196
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[286].y
+      value: 0.7675443
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[286].z
+      value: 0.453253
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[287].x
+      value: -0.0000007514773
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[287].y
+      value: 0.76754415
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[287].z
+      value: 0.6409961
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[288].x
+      value: -0.9957564
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[288].y
+      value: -0.09202814
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[288].z
+      value: 0.00000013481097
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[289].x
+      value: -0.7041072
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[289].y
+      value: -0.09202777
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[289].z
+      value: 0.7041051
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[290].x
+      value: -0.4532532
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[290].y
+      value: 0.76754385
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[290].z
+      value: 0.4532527
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[291].x
+      value: -0.6409961
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[291].y
+      value: 0.76754415
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[291].z
+      value: 0.00000052838226
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[292].x
+      value: -0.0000012518188
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[292].y
+      value: -0.09202968
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[292].z
+      value: -0.99575627
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[293].x
+      value: -0.70410657
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[293].y
+      value: -0.09202971
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[293].z
+      value: -0.70410544
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[294].x
+      value: -0.4532537
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[294].y
+      value: 0.76754385
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[294].z
+      value: -0.45325208
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[295].x
+      value: -0.0000008923785
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[295].y
+      value: 0.7675451
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[295].z
+      value: -0.6409949
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[296].x
+      value: 0.7041054
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[296].y
+      value: -0.09203016
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[296].z
+      value: -0.70410657
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[297].x
+      value: -0.0000012518188
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[297].y
+      value: -0.09202968
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[297].z
+      value: -0.99575627
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[298].x
+      value: -0.0000008923785
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[298].y
+      value: 0.7675451
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[298].z
+      value: -0.6409949
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[299].x
+      value: 0.4532521
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[299].y
+      value: 0.767545
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[299].z
+      value: -0.45325187
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[300].x
+      value: 0.7041061
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[300].y
+      value: -0.09202878
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[300].z
+      value: 0.70410603
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[301].x
+      value: 0.9957562
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[301].y
+      value: -0.09202991
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[301].z
+      value: 0.00000024073435
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[302].x
+      value: 0.6409953
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[302].y
+      value: 0.76754475
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[302].z
+      value: 0.0000005166404
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[303].x
+      value: 0.45325196
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[303].y
+      value: 0.7675443
+      objectReference: {fileID: 0}
+    - target: {fileID: 7412144944621722096, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: bakeValues.Array.data[0].data.Array.data[303].z
+      value: 0.453253
+      objectReference: {fileID: 0}
+    - target: {fileID: 8457531813973412868, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: doorLock
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8457531813973412868, guid: aee1476490b145e4cbe08108b7480b99, type: 3}
+      propertyPath: lockTrigger
+      value: 
+      objectReference: {fileID: 2120756527}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
@@ -3300,6 +10651,17 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 3781d9cbfa3180f459531695abb39ed8, type: 3}
+--- !u!114 &2120756527 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 9201742927471348575, guid: 3781d9cbfa3180f459531695abb39ed8, type: 3}
+  m_PrefabInstance: {fileID: 2120756526}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1d2663fd446eebc41b3ca745f13bd505, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &6321830509365440332
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/PSH.unity
+++ b/Assets/Scenes/PSH.unity
@@ -176,149 +176,11 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 293212ecd20335647abc1a82e7d714e0, type: 3}
---- !u!1 &380182763
+--- !u!1 &380182763 stripped
 GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 4702292506888140698, guid: c19c588feb39d7c4dbf30be65012fbbe, type: 3}
+  m_PrefabInstance: {fileID: 6159326004210379420}
   m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 380182767}
-  - component: {fileID: 380182766}
-  - component: {fileID: 380182765}
-  - component: {fileID: 380182764}
-  - component: {fileID: 380182769}
-  - component: {fileID: 380182768}
-  m_Layer: 6
-  m_Name: Key
-  m_TagString: Interactable
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!136 &380182764
-CapsuleCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 380182763}
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_IsTrigger: 0
-  m_ProvidesContacts: 0
-  m_Enabled: 1
-  serializedVersion: 2
-  m_Radius: 0.5000001
-  m_Height: 2
-  m_Direction: 1
-  m_Center: {x: 0.000000059604645, y: 0, z: -0.00000008940697}
---- !u!23 &380182765
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 380182763}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 2
-  m_RayTraceProcedural: 0
-  m_RayTracingAccelStructBuildFlagsOverride: 0
-  m_RayTracingAccelStructBuildFlags: 1
-  m_SmallMeshCulling: 1
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: 31321ba15b8f8eb4c954353edc038b1d, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  m_AdditionalVertexStreams: {fileID: 0}
---- !u!33 &380182766
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 380182763}
-  m_Mesh: {fileID: 10206, guid: 0000000000000000e000000000000000, type: 0}
---- !u!4 &380182767
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 380182763}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 3.3, y: 1.55, z: 1.94}
-  m_LocalScale: {x: 0.05, y: 0.05, z: 0.05}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 0}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &380182768
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 380182763}
-  m_Enabled: 0
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 5fea29bb7c508c244a1f805a5fd3fc4d, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  outlineMode: 0
-  outlineColor: {r: 1, g: 0.92156863, b: 0.015686275, a: 1}
-  outlineWidth: 10
-  precomputeOutline: 0
-  bakeKeys: []
-  bakeValues: []
---- !u!114 &380182769
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 380182763}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: e00e09a48e8a87340be7acd9ed84861d, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  targetDoor: {fileID: 1988850391}
 --- !u!1 &410087039
 GameObject:
   m_ObjectHideFlags: 0
@@ -448,6 +310,10 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 1170576051356645374, guid: e9e6087e900be2f40b41bd299c6341b3, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 2649308893299597789, guid: e9e6087e900be2f40b41bd299c6341b3, type: 3}
       propertyPath: m_Name
       value: Player
@@ -968,17 +834,6 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1988850391 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 33416811221130813, guid: 5106e3a183ba4234d9161ab63b05148e, type: 3}
-  m_PrefabInstance: {fileID: 7181550535051591628}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 9118635186edf8044b0790f596c7ee90, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1001 &4710435492656626832
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1888,6 +1743,63 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 3781d9cbfa3180f459531695abb39ed8, type: 3}
+--- !u!1001 &6159326004210379420
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 27933675974785757, guid: c19c588feb39d7c4dbf30be65012fbbe, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 3.3
+      objectReference: {fileID: 0}
+    - target: {fileID: 27933675974785757, guid: c19c588feb39d7c4dbf30be65012fbbe, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1.55
+      objectReference: {fileID: 0}
+    - target: {fileID: 27933675974785757, guid: c19c588feb39d7c4dbf30be65012fbbe, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 1.94
+      objectReference: {fileID: 0}
+    - target: {fileID: 27933675974785757, guid: c19c588feb39d7c4dbf30be65012fbbe, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 27933675974785757, guid: c19c588feb39d7c4dbf30be65012fbbe, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 27933675974785757, guid: c19c588feb39d7c4dbf30be65012fbbe, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 27933675974785757, guid: c19c588feb39d7c4dbf30be65012fbbe, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 27933675974785757, guid: c19c588feb39d7c4dbf30be65012fbbe, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 27933675974785757, guid: c19c588feb39d7c4dbf30be65012fbbe, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 27933675974785757, guid: c19c588feb39d7c4dbf30be65012fbbe, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4702292506888140698, guid: c19c588feb39d7c4dbf30be65012fbbe, type: 3}
+      propertyPath: m_Name
+      value: Key
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: c19c588feb39d7c4dbf30be65012fbbe, type: 3}
 --- !u!114 &6687960101987469647 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 9201742927471348575, guid: 3781d9cbfa3180f459531695abb39ed8, type: 3}
@@ -1955,6 +1867,10 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 4406269088958431164, guid: 5106e3a183ba4234d9161ab63b05148e, type: 3}
+      propertyPath: keyPrefab
+      value: 
+      objectReference: {fileID: 380182763}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
@@ -1971,7 +1887,7 @@ SceneRoots:
   - {fileID: 4710435492656626832}
   - {fileID: 7181550535051591628}
   - {fileID: 684801572}
-  - {fileID: 380182767}
+  - {fileID: 6159326004210379420}
   - {fileID: 1678459743}
   - {fileID: 222049166}
   - {fileID: 1453445577}

--- a/Assets/ScriptableObject/SymbolWeight.asset
+++ b/Assets/ScriptableObject/SymbolWeight.asset
@@ -14,18 +14,18 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   weightedSymbols:
   - symbol: 1
-    probability: 100
+    probability: 19.4
   - symbol: 2
-    probability: 0
+    probability: 19.4
   - symbol: 3
-    probability: 0
+    probability: 14.9
   - symbol: 4
-    probability: 0
+    probability: 14.9
   - symbol: 5
-    probability: 0
+    probability: 11.9
   - symbol: 6
-    probability: 0
+    probability: 11.9
   - symbol: 7
-    probability: 0
+    probability: 7.6
   - symbol: 8
     probability: 0

--- a/Assets/ScriptableObject/SymbolWeight.asset
+++ b/Assets/ScriptableObject/SymbolWeight.asset
@@ -14,18 +14,18 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   weightedSymbols:
   - symbol: 1
-    probability: 19.4
+    probability: 100
   - symbol: 2
-    probability: 19.4
+    probability: 0
   - symbol: 3
-    probability: 14.9
+    probability: 0
   - symbol: 4
-    probability: 14.9
+    probability: 0
   - symbol: 5
-    probability: 11.9
+    probability: 0
   - symbol: 6
-    probability: 11.9
+    probability: 0
   - symbol: 7
-    probability: 7.6
+    probability: 0
   - symbol: 8
     probability: 0

--- a/Assets/ScriptableObject/SymbolWeight.asset
+++ b/Assets/ScriptableObject/SymbolWeight.asset
@@ -27,3 +27,5 @@ MonoBehaviour:
     probability: 11.9
   - symbol: 7
     probability: 7.6
+  - symbol: 8
+    probability: 0

--- a/Assets/Scripts/Door/AutoLockTrigger.cs
+++ b/Assets/Scripts/Door/AutoLockTrigger.cs
@@ -1,20 +1,12 @@
 using UnityEngine;
-using UnityEngine.Events;
 public class AutoLockTrigger : MonoBehaviour, IInteractable
 {
-    [Tooltip("상호작용 시 발생할 이벤트입니다.")]
-    public UnityEvent OnInteracted;
-
-    [Tooltip("한 번만")]
-    public bool interactOnce = true;
-
     public void Interact()
     {
-        OnInteracted?.Invoke();
-
-        if (interactOnce)
+        if (GameManager.instance != null)
         {
-            this.enabled = false;
+            Debug.Log("AutoLockTrigger 발동! 모든 문을 잠급니다.");
+            GameManager.instance.TriggerLockAllDoors();
         }
     }
 }

--- a/Assets/Scripts/Door/Door.cs
+++ b/Assets/Scripts/Door/Door.cs
@@ -7,9 +7,6 @@ public class Door : MonoBehaviour, IInteractable
     [Tooltip("상호작용 시 색상을 변경할 Outline 컴포넌트")]
     public Outline outline;
 
-    [Tooltip("이 오브젝트와 상호작용 시 문이 자동 잠김")]
-    public AutoLockTrigger lockTrigger;
-
     [Header("상태")]
     [Tooltip("문이 잠겼는지 여부")]
     [SerializeField]
@@ -46,10 +43,10 @@ public class Door : MonoBehaviour, IInteractable
 
         InitializeAnimatorHashes();
 
-        // GameManager가 존재하면, OnUnlockDoor 이벤트가 발생할 때 Unlock 메서드를 실행하도록 등록합니다.
         if (GameManager.instance != null)
         {
             GameManager.instance.OnUnlockDoor += Unlock;
+            GameManager.instance.OnLockAllDoors += Lock;
         }
 
         InitializeOutline();
@@ -57,18 +54,6 @@ public class Door : MonoBehaviour, IInteractable
 
     private void OnEnable()
     {
-        if (lockTrigger != null)
-        {
-            lockTrigger.OnInteracted.AddListener(AutoCloseAndLock);
-        }
-    }
-
-    private void OnDisable()
-    {
-        if (lockTrigger != null)
-        {
-            lockTrigger.OnInteracted.RemoveListener(AutoCloseAndLock);
-        }
     }
 
     private void OnDestroy()
@@ -76,6 +61,7 @@ public class Door : MonoBehaviour, IInteractable
         if (GameManager.instance != null)
         {
             GameManager.instance.OnUnlockDoor -= Unlock;
+            GameManager.instance.OnLockAllDoors -= Lock;
         }
     }
 
@@ -107,6 +93,12 @@ public class Door : MonoBehaviour, IInteractable
     public void Lock()
     {
         if (doorLock) return;
+
+        // 문이 열려있으면 먼저 닫습니다.
+        if (isOpen)
+        {
+            Close();
+        }
 
         SetLockedState(true);
         Debug.Log("문이 잠겼습니다.");
@@ -143,20 +135,6 @@ public class Door : MonoBehaviour, IInteractable
 
         animator.SetTrigger(closeTriggerHash);
         isOpen = false;
-    }
-
-    /// <summary>
-    /// 문 자동 잠금. lockTrigger에 의해 호출
-    /// </summary>
-    public void AutoCloseAndLock()
-    {
-        if (isOpen)
-        {
-            Close();
-        }
-
-        SetLockedState(true);
-        Debug.Log("문이 자동으로 닫히고 잠겼습니다.");
     }
 
     /// <summary>

--- a/Assets/Scripts/Door/DoorManager.cs.meta
+++ b/Assets/Scripts/Door/DoorManager.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: c0ba4f9df660af34c9d7127ff352a6dd

--- a/Assets/Scripts/Door/DoorManager.cs.meta
+++ b/Assets/Scripts/Door/DoorManager.cs.meta
@@ -1,2 +1,0 @@
-fileFormatVersion: 2
-guid: c0ba4f9df660af34c9d7127ff352a6dd

--- a/Assets/Scripts/Door/KeySpawner.cs
+++ b/Assets/Scripts/Door/KeySpawner.cs
@@ -1,0 +1,62 @@
+using UnityEngine;
+
+public class KeySpawner : MonoBehaviour
+{
+    [Tooltip("생성할 열쇠 프리팹")]
+    public GameObject keyPrefab;
+
+    [Tooltip("열쇠가 생성될 위치")]
+    public Transform spawnPoint;
+
+    [Tooltip("이 열쇠가 생성될 레벨")]
+    public int targetLevel = 2;
+
+    private GameObject _spawnedKey;
+
+    private void Start()
+    {
+        LevelManager levelManager = FindObjectOfType<LevelManager>();
+        if (levelManager != null)
+        {
+            levelManager.OnLevelUp += SpawnKeyIfLevelMatches;
+        }
+
+        if (keyPrefab == null)
+        {
+            Debug.LogError("Key Prefab이 할당되지 않았습니다.", this);
+        }
+        if (spawnPoint == null)
+        {
+            Debug.LogError("Spawn Point가 할당되지 않았습니다.", this);
+        }
+    }
+
+    private void OnDestroy()
+    {
+        LevelManager levelManager = FindObjectOfType<LevelManager>();
+        if (levelManager != null)
+        {
+            levelManager.OnLevelUp -= SpawnKeyIfLevelMatches;
+        }
+    }
+
+    private void SpawnKeyIfLevelMatches(int newLevel)
+    {
+        // 현재 레벨이 목표랑 일치하고 열쇠가 없을 때 열쇠 생성
+        if (newLevel == targetLevel && keyPrefab != null && spawnPoint != null && _spawnedKey == null)
+        {
+            // 열쇠 프리팹
+            _spawnedKey = Instantiate(keyPrefab, spawnPoint.position, spawnPoint.rotation);
+
+            // 생성된 열쇠에서 Unlock 스크립트
+            Unlock unlockScript = _spawnedKey.GetComponent<Unlock>();
+            if (unlockScript != null)
+            {
+                // 열쇠 생성기가 붙어있는 문 찾기
+                unlockScript.targetDoor = GetComponent<Door>();
+            }
+
+            Debug.Log($"레벨 {newLevel} 달성! '{gameObject.name}' 문 앞에 열쇠가 생성되었습니다.");
+        }
+    }
+}

--- a/Assets/Scripts/Door/KeySpawner.cs.meta
+++ b/Assets/Scripts/Door/KeySpawner.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 0338860f622ec0148b7ef7309630c76b

--- a/Assets/Scripts/Door/Unlock.cs
+++ b/Assets/Scripts/Door/Unlock.cs
@@ -1,7 +1,5 @@
 using UnityEngine;
 
-// 이 스크립트는 IInteractable 인터페이스를 사용합니다.
-// 프로젝트에 있는 Interaction 관련 스크립트가 필요합니다.
 public class Unlock : MonoBehaviour, IInteractable
 {
     [Tooltip("이 열쇠로 열 수 있는 문")]
@@ -11,15 +9,15 @@ public class Unlock : MonoBehaviour, IInteractable
 
     public void Interact()
     {
-        if (targetDoor != null)
+        if (targetDoor != null && GameManager.instance != null)
         {
+            // 소지금의 10% 소모
+            int cost = (int)(GameManager.instance.money._gold * 0.1f);
+            GameManager.instance.money.SpendGold(cost);
+
             // 문 잠금 해제
             targetDoor.Unlock();
-            Debug.Log($"'{targetDoor.name}' 문의 잠금을 해제했습니다.");
-        }
-        else
-        {
-            Debug.LogWarning("열쇠에 연결된 문이 없습니다.", this);
+            Debug.Log($"'{targetDoor.name}' 문의 잠금을 해제했습니다. (소모된 골드: {cost})");
         }
 
         // 상호작용 후 열쇠 오브젝트는 비활성화

--- a/Assets/Scripts/Enum/Symbols.cs
+++ b/Assets/Scripts/Enum/Symbols.cs
@@ -7,6 +7,7 @@ public enum Symbols
     Carrot = 3,
     Bell = 4,
     Diamond = 5,
-    Star = 6 ,
-    Seven = 7 
+    Star = 6,
+    Seven = 7,
+    Skull = 8
 }

--- a/Assets/Scripts/Level/LevelData.cs
+++ b/Assets/Scripts/Level/LevelData.cs
@@ -21,9 +21,9 @@ public class LevelData
         if (_level == level && _level != 0) return;
 
         _level = level;
-        _minGold = level * CONVERT_SIZE;
-        _maxGold = level * MAX_SIZE * CONVERT_SIZE;
-        _unitGold = _minGold * level;
+        _minGold = level * CONVERT_SIZE; // 베팅 시 최소 골드
+        _maxGold = level * MAX_SIZE * CONVERT_SIZE; // 베팅 시 최대 골드
+        _unitGold = _minGold; // 베팅 시 단위 골드
 
         // 레벨 변경
         Debug.Log($"레벨을 {level}(으)로 올립니다.");

--- a/Assets/Scripts/LevelManager.cs
+++ b/Assets/Scripts/LevelManager.cs
@@ -1,0 +1,42 @@
+using System;
+using UnityEngine;
+
+public class LevelManager : MonoBehaviour
+{
+    public event Action<int> OnLevelUp;
+
+    private Money _money;
+    private LevelData _levelData;
+
+    public void Initialize(Money money, LevelData levelData)
+    {
+        _money = money;
+        _levelData = levelData;
+
+        if (_money != null)
+        {
+            _money.OnMoneyChanged += CheckLevelUp;
+        }
+    }
+
+    private void OnDestroy()
+    {
+        if (_money != null)
+        {
+            _money.OnMoneyChanged -= CheckLevelUp;
+        }
+    }
+    // 레벨 오르는 조건
+    private void CheckLevelUp()
+    {
+        if (_money == null || _levelData == null) return;
+
+        // 소지금이 현재 레벨의 최대치(_maxGold)를 초과하면 레벨업
+        if (_money._gold > _levelData._maxGold * 50)
+        {
+            int newLevel = _levelData._level + 1;
+            _levelData.SetLevel(newLevel);
+            OnLevelUp?.Invoke(newLevel);
+        }
+    }
+}

--- a/Assets/Scripts/LevelManager.cs.meta
+++ b/Assets/Scripts/LevelManager.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 5e3c8661294964e49800dbab37cd398e

--- a/Assets/Scripts/Slotmachine/BetScreen.cs
+++ b/Assets/Scripts/Slotmachine/BetScreen.cs
@@ -51,13 +51,13 @@ public class BetScreen : MonoBehaviour
         bettingGoldText.text = newBettingGold.ToString("N0") + " $";
 
         // 베팅 금액에 따라 텍스트 색상 변경
-        if (GameManager.instance != null)
+        if (slotMachine != null)
         {
-            if (newBettingGold >= GameManager.instance.levelData._maxGold)
+            if (newBettingGold >= slotMachine.MaxBettingGold)
             {
                 bettingGoldText.color = maxBetColor;
             }
-            else if (newBettingGold <= GameManager.instance.levelData._minGold)
+            else if (newBettingGold <= slotMachine.MinBettingGold)
             {
                 bettingGoldText.color = minBetColor;
             }

--- a/Assets/Scripts/Slotmachine/BtnMotion.cs
+++ b/Assets/Scripts/Slotmachine/BtnMotion.cs
@@ -32,7 +32,7 @@ public class BtnMotion : MonoBehaviour, IInteractable
         // leverAnim이 할당되었는지 확인 후 애니메이션 실행
         if (btnAnim != null)
         {
-            Debug.Log("버튼 누름...");
+            // Debug.Log("버튼 누름...");
             btnAnim.SetTrigger("Press");
         }
         else

--- a/Assets/Scripts/Slotmachine/LeverMotion.cs
+++ b/Assets/Scripts/Slotmachine/LeverMotion.cs
@@ -15,7 +15,6 @@ public class LeverMotion : MonoBehaviour, IInteractable
     [SerializeField] private Color disabledColor = Color.red;
 
     [Tooltip("레버의 상태를 제어할 SlotMachine 컴포넌트")]
-    // TODO: SlotMachine 컴포넌트를 찾지 못했을 때의 예외 처리를 강화할 필요가 있습니다.
     [SerializeField] private SlotMachine slotMachine;
 
     [Header("Effects")]
@@ -144,7 +143,7 @@ public class LeverMotion : MonoBehaviour, IInteractable
 
     private IEnumerator SparkEffectSequence()
     {
-        Debug.Log("스파크 효과 재생!");
+        // Debug.Log("스파크 효과 재생!");
 
         sparkAnimator.gameObject.SetActive(true);
         sparkAnimator.Play(0, -1, 0f);


### PR DESCRIPTION
레벨 매니저
- 레벨업 시 새로운 레벨을 이벤트 발생 시켜 다른 컴포넌트에게 뿌림

KeySpawner
- 레벨업 이벤트를 구독 -> 레벨이 일치할 경우 key를 문 앞에 소환(특정 문에 종속)

Unlock
- 열쇠 상호작용(소지금 10% 소모)

Slotmachine
- BetScreen이 GameManager에 직접 의존 하지 않게함(min, max 골드 프로퍼티로 외부에 제공하도록 함)
- 레벨 변경 될 때마다 이벤트 받아서 한도 갱신
- 베팅 금액 최대/최소가 변동 될 때 최소나 최대로 가지 않는 로직 수정

GameManager
- 문 모두 잠금 이벤트랑 호출하는 트리거 메소드 추가(임시)


https://github.com/user-attachments/assets/c4215244-14c6-482c-9bb0-0b56e0dc5ec8

